### PR TITLE
set proper origin for the iframe communication

### DIFF
--- a/components/iframeCommunication.js
+++ b/components/iframeCommunication.js
@@ -1,14 +1,28 @@
 import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 
-// not used as there's no access to the parent origin. This is not ideal as anyone can embed the documentation and receive messages.
-// const allowedOrigins = ['https://alkem.io', 'https://dev-alkem.io', 'https://acc-alkem.io', 'https://sandbox-alkem.io', 'http://localhost:3000'];
-// const isOriginValid = (origin) => allowedOrigins.includes(origin);
+const allowedOrigins = ['https://alkem.io', 'https://dev-alkem.io', 'https://acc-alkem.io', 'https://sandbox-alkem.io', 'http://localhost:3000'];
+const isOriginValid = (origin) => allowedOrigins.includes(origin);
+
+const getCurrentOrigin = () => {
+    const { protocol, hostname, origin, port } = window.location;
+    if (port) {
+        return `${protocol}//${hostname}:3000`; // local client port
+    }
+
+    return origin;
+};
 
 const sendMessageToParent = (message) => {
     try {
-        // todo: check for isOriginValid here
-        window.parent.postMessage(message, '*');
+        const origin = getCurrentOrigin();
+
+        if (!isOriginValid(origin)) {
+            console.warn('Invalid origin: ', origin);
+            return;
+        }
+
+        window.parent.postMessage(message, getCurrentOrigin());
     } catch (error) {
         console.warn('Failed to send message to parent: ', error);
     }


### PR DESCRIPTION
set the proper origin so the communication between the iframe and the platform works on all Alkemio environments 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a validation mechanism for iframe message origins, enhancing security.
	- Added functionality to determine and validate the current origin before sending messages.
  
- **Bug Fixes**
	- Improved handling of message sending by ensuring only messages from allowed origins are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->