### PR TITLE
Show text when iframe is not loading

### DIFF
--- a/pages/support-form.js
+++ b/pages/support-form.js
@@ -1,0 +1,26 @@
+import React, { useState, useEffect } from 'react';
+
+const IframeComponent = () => {
+ const [isLoaded, setIsLoaded] = useState(false);
+
+ useEffect(() => {
+ const iframe = document.querySelector('iframe');
+ iframe.addEventListener('load', () => {
+ setIsLoaded(true);
+ });
+ }, []);
+
+ return (
+ <div style={{ position: 'relative', width: '100%', height: '700px', marginTop: '20px' }}>
+ {!isLoaded && <p>This block should show a support form. If that is not a case, try a different browser or check if there is an ad-blocke active.</p>}
+ <iframe
+ src="https://share-eu1.hsforms.com/1IKi5Eg2DT3C1BoWQzNQ0Eg2drqet"
+ title="Embedded Form"
+ frameborder="0"
+ style={{ width: '100%', height: '100%', display: isLoaded ? 'block' : 'none' }}
+ ></iframe>
+ </div>
+ );
+};
+
+export default IframeComponent;

--- a/pages/support-form.js
+++ b/pages/support-form.js
@@ -31,10 +31,10 @@ const IframeComponent = () => {
  borderRadius: '10px',
  boxShadow: '0 0 10px rgba(0,0,0,0.1)'
  }}>
- {status == 'loading' && (
+ {status === 'loading' && (
       <p style={{ textAlign: 'center' }}>Loading support form...</p>
     )}
-    {status == 'error' && (
+    {status === 'error' && (
       <p style={{ textAlign: 'center' }}>
         We couldn't load the support form. Please try a different browser, check if you have an ad-blocker active, or <a href="mailto:support@alkem.io">contact us directly</a>.
       </p>
@@ -43,7 +43,7 @@ const IframeComponent = () => {
  ref={iframeRef}
  src="https://share-eu1.hsforms.com/1IKi5Eg2DT3C1BoWQzNQ0Eg2drqet"
  title="Embedded Form"
- frameborder="0"
+ frameBorder="0"
  style={{ width: '100%', height: '100%', display: status === 'loaded' ? 'block' : 'none', border: 'none' }}
  ></iframe>
  </div>

--- a/pages/support-form.js
+++ b/pages/support-form.js
@@ -11,8 +11,18 @@ const IframeComponent = () => {
  }, []);
 
  return (
- <div style={{ position: 'relative', width: '100%', height: '700px', marginTop: '20px' }}>
- {!isLoaded && <p>This block should show a support form. If that is not a case, try a different browser or check if there is an ad-blocke active.</p>}
+ <div style={{
+ position: 'relative',
+ width: '100%',
+ maxWidth: '600px',
+ margin: '40px auto',
+ padding: '20px',
+ backgroundColor: '#f9f9f9',
+ border: '1px solid #ddd',
+ borderRadius: '10px',
+ boxShadow: '0 0 10px rgba(0,0,0,0.1)'
+ }}>
+ {!isLoaded && <p style={{ textAlign: 'center' }}>This block should show a support form. If that is not a case, try a different browser or check if there is an ad-blocker active.</p>}
  <iframe
  src="https://share-eu1.hsforms.com/1IKi5Eg2DT3C1BoWQzNQ0Eg2drqet"
  title="Embedded Form"

--- a/pages/support-form.js
+++ b/pages/support-form.js
@@ -51,7 +51,7 @@ const SupportForm = () => {
         width: '100%', 
         height: '100%', 
         border: 'none',
-
+        opacity: status === states.LOADED ? 1 : 0,
         transition: 'opacity 0.3s ease-in-out',
       }}
     />

--- a/pages/support-form.js
+++ b/pages/support-form.js
@@ -1,53 +1,62 @@
 import React, { useState, useEffect } from 'react';
 
-const IframeComponent = () => {
- const [status, setStatus] = useState('loading'); // 'loading', 'loaded', 'error'
- const iframeRef = React.useRef(null);
+const states = {
+  LOADING: 'loading',
+  LOADED: 'loaded',
+  ERROR: 'error',
+};
 
- useEffect(() => {
- const iframe = iframeRef.current;
- if (iframe) {
-    const handleLoad = () => setStatus('loaded');
-    const handleError = () => setStatus('error');
-    iframe.addEventListener('load', handleLoad);
-    iframe.addEventListener('error', handleError);
-    return () => {
-        iframe.removeEventListener('load', handleLoad);
-        iframe.removeEventListener('error', handleError);
-    };
- }
- }, []);
+const SupportForm = () => {
+ const [status, setStatus] = useState(states.LOADING);
+ const [iframeSrc, setIframeSrc] = useState();
+
+  useEffect(() => {
+    // Delay setting src to ensure onLoad can be captured
+    setIframeSrc('https://share-eu1.hsforms.com/1IKi5Eg2DT3C1BoWQzNQ0Eg2drqet');
+  }, []);
+
+  const handleLoad = () => setStatus(states.LOADED);
+  const handleError = () => setStatus(states.ERROR);
 
  return (
- <div style={{
- position: 'relative',
- width: '100%',
- maxWidth: '600px',
- height: '700px',
- margin: '40px auto',
- padding: '20px',
- backgroundColor: '#f9f9f9',
- border: '1px solid #ddd',
- borderRadius: '10px',
- boxShadow: '0 0 10px rgba(0,0,0,0.1)'
- }}>
- {status === 'loading' && (
+  <div 
+    style={{
+      position: 'relative',
+      width: '100%',
+      maxWidth: '600px',
+      height: '700px',
+      margin: '40px auto',
+      padding: '20px',
+      backgroundColor: '#f9f9f9',
+      border: '1px solid #ddd',
+      borderRadius: '10px',
+      boxShadow: '0 0 10px rgba(0,0,0,0.1)'
+    }}
+  >
+    {status === states.LOADING && (
       <p style={{ textAlign: 'center' }}>Loading support form...</p>
     )}
-    {status === 'error' && (
+    {status === states.ERROR && (
       <p style={{ textAlign: 'center' }}>
         We couldn't load the support form. Please try a different browser, check if you have an ad-blocker active, or <a href="mailto:support@alkem.io">contact us directly</a>.
       </p>
     )}
- <iframe
- ref={iframeRef}
- src="https://share-eu1.hsforms.com/1IKi5Eg2DT3C1BoWQzNQ0Eg2drqet"
- title="Embedded Form"
- frameBorder="0"
- style={{ width: '100%', height: '100%', display: status === 'loaded' ? 'block' : 'none', border: 'none' }}
- ></iframe>
+    <iframe
+      src={iframeSrc}
+      title="Embedded Form"
+      onLoad={handleLoad}
+      onError={handleError}
+      frameBorder="0"
+      style={{ 
+        width: '100%', 
+        height: '100%', 
+        border: 'none',
+
+        transition: 'opacity 0.3s ease-in-out',
+      }}
+    />
  </div>
  );
 };
 
-export default IframeComponent;
+export default SupportForm;

--- a/pages/support-form.js
+++ b/pages/support-form.js
@@ -1,13 +1,21 @@
 import React, { useState, useEffect } from 'react';
 
 const IframeComponent = () => {
- const [isLoaded, setIsLoaded] = useState(false);
+ const [status, setStatus] = useState('loading'); // 'loading', 'loaded', 'error'
+ const iframeRef = React.useRef(null);
 
  useEffect(() => {
- const iframe = document.querySelector('iframe');
- iframe.addEventListener('load', () => {
- setIsLoaded(true);
- });
+ const iframe = iframeRef.current;
+ if (iframe) {
+    const handleLoad = () => setStatus('loaded');
+    const handleError = () => setStatus('error');
+    iframe.addEventListener('load', handleLoad);
+    iframe.addEventListener('error', handleError);
+    return () => {
+        iframe.removeEventListener('load', handleLoad);
+        iframe.removeEventListener('error', handleError);
+    };
+ }
  }, []);
 
  return (
@@ -23,12 +31,20 @@ const IframeComponent = () => {
  borderRadius: '10px',
  boxShadow: '0 0 10px rgba(0,0,0,0.1)'
  }}>
- {!isLoaded && <p style={{ textAlign: 'center' }}>This block should show a support form. If that is not a case, try a different browser or check if there is an ad-blocker active.</p>}
+ {status == 'loading' && (
+      <p style={{ textAlign: 'center' }}>Loading support form...</p>
+    )}
+    {status == 'error' && (
+      <p style={{ textAlign: 'center' }}>
+        We couldn't load the support form. Please try a different browser, check if you have an ad-blocker active, or <a href="mailto:support@alkem.io">contact us directly</a>.
+      </p>
+    )}
  <iframe
+ ref={iframeRef}
  src="https://share-eu1.hsforms.com/1IKi5Eg2DT3C1BoWQzNQ0Eg2drqet"
  title="Embedded Form"
  frameborder="0"
- style={{ width: '100%', height: '100%', display: isLoaded ? 'block' : 'none' }}
+ style={{ width: '100%', height: '100%', display: status === 'loaded' ? 'block' : 'none', border: 'none' }}
  ></iframe>
  </div>
  );

--- a/pages/support-form.js
+++ b/pages/support-form.js
@@ -15,6 +15,7 @@ const IframeComponent = () => {
  position: 'relative',
  width: '100%',
  maxWidth: '600px',
+ height: '700px',
  margin: '40px auto',
  padding: '20px',
  backgroundColor: '#f9f9f9',

--- a/pages/support.en-US.mdx
+++ b/pages/support.en-US.mdx
@@ -3,14 +3,9 @@
 We are a small team, but we move fast and your success is ours! 
 If you still have questions, you can fill out the form below, and we’ll get back to you within two business days. 
 
-<div style={{ position: 'relative', width: '100%', height: '700px', marginTop: '20px' }}>
-    <iframe
-        src="https://share-eu1.hsforms.com/1IKi5Eg2DT3C1BoWQzNQ0Eg2drqet" 
-        title="Embedded Form"
-        frameborder="0"
-        style={{ width: '100%', height: '100%' }}
-    ></iframe>
-</div>
+import IframeComponent from './support-form';
+
+<IframeComponent />
 
 
 Send us an [email](mailto:support@alkem.io) or visit us on [our website](https://welcome.alkem.io/contact).

--- a/pages/support.en-US.mdx
+++ b/pages/support.en-US.mdx
@@ -3,9 +3,9 @@
 We are a small team, but we move fast and your success is ours! 
 If you still have questions, you can fill out the form below, and we’ll get back to you within two business days. 
 
-import IframeComponent from './support-form';
+import SupportForm from './support-form';
 
-<IframeComponent />
+<SupportForm />
 
 
 Send us an [email](mailto:support@alkem.io) or visit us on [our website](https://welcome.alkem.io/contact).


### PR DESCRIPTION
### Describe the background of your pull request

added extra file for the support form iframe, so extra logic could be added to show text in case the iframe is not loading.

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the support page with a new styled support form component that provides loading feedback and helpful error messages with contact options.

- **Refactor**
  - Replaced the static iframe embed with a reusable support form component for improved maintainability and user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->