### PR TITLE
Fix the broken i18n links

### DIFF
--- a/components/iframeCommunication.js
+++ b/components/iframeCommunication.js
@@ -59,8 +59,8 @@ const IframeCommunication = () => {
     
 
     useEffect(() => {
-        // Send path
-        sendMessageToParent({ type: SupportedMessageTypes.PageChange, url: router.pathname });
+        // Send path, use asPath as pathname includes the locale at the end
+        sendMessageToParent({ type: SupportedMessageTypes.PageChange, url: router.asPath });
 
         // Observe changes to the body size
         const resizeObserver = new ResizeObserver(sendPageHeight);

--- a/next.config.js
+++ b/next.config.js
@@ -12,5 +12,14 @@ module.exports = withNextra({
     images: {
     unoptimized: true,
     },
-    basePath: '/documentation',   
+    basePath: '/documentation',
+    async redirects() {
+        return [
+          {
+            source: '/:path*.:lang([a-z]{2}-[A-Z]{2})', // matches .nl-NL, .en-US etc.
+            destination: '/:path*',
+            permanent: true,
+          },
+        ];
+      },
 });

--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -2,7 +2,6 @@ export default {
     logo: <span></span>,
     primaryHue: { dark: 215, light: 215 },
     primarySaturation: { dark: 50, light: 50 },
-    theme: 'light',
     darkMode: false,
     nextThemes: {
         defaultTheme: 'light',
@@ -12,11 +11,7 @@ export default {
         { locale: 'en-US', text: 'English' },
         { locale: 'nl-NL', text: 'Nederlands' },
     ],
-    project: {
-        title: "Alkemio - Safe Spaces for Collaboration",
-        description: "Join Alkemio! Achieve your goals. Safe smart spaces for collective action."
-      },
-      head: (
+    head: (
         <>
           <title>Alkemio - Safe Spaces for Collaboration</title>
           <meta name="description" content="Join Alkemio! Achieve your goals. Safe smart spaces for collective action." />


### PR DESCRIPTION
Fix broken i18n links by removing the locale in the URL. 
Adding redirecting logic for legacy links.

_Unrelated_
Fix console errors due to unsupported keys in the theme config.
