### PR TITLE
feat: info banner for pending sync of docs with latest platform design

### DIFF
--- a/app/[lang]/layout.jsx
+++ b/app/[lang]/layout.jsx
@@ -1,10 +1,11 @@
 import { Footer, Layout, Navbar, LocaleSwitch } from 'nextra-theme-docs'
-import { Head } from 'nextra/components'
+import { Head, Banner } from 'nextra/components'
 import { getPageMap } from 'nextra/page-map'
 import 'nextra-theme-docs/style.css'
 import '../../styles.css'
 import ClientProviders from '../_components/ClientProviders'
 import LocaleSwitchWrapper from '../_components/LocaleSwitchWrapper'
+import { BANNER_STORAGE_KEY, getBannerText } from '../_components/banner-content'
 
 export const metadata = {
   metadataBase: new URL('https://alkem.io'),
@@ -41,6 +42,15 @@ export default async function RootLayout({ children, params }) {
     </Footer>
   )
 
+  // Global, dismissible info banner: warns that the docs visuals are pending an
+  // update to match the new platform UI. Locale-aware; the versioned storageKey
+  // re-shows the banner whenever the copy/key changes.
+  const banner = (
+    <Banner storageKey={BANNER_STORAGE_KEY}>
+      {getBannerText(lang)}
+    </Banner>
+  )
+
   return (
     <html lang={lang} dir="ltr" suppressHydrationWarning>
       <Head />
@@ -48,6 +58,7 @@ export default async function RootLayout({ children, params }) {
         <ClientProviders />
         <LocaleSwitchWrapper />
         <Layout
+          banner={banner}
           navbar={navbar}
           footer={footer}
           pageMap={pageMap}

--- a/app/_components/banner-content.js
+++ b/app/_components/banner-content.js
@@ -1,0 +1,29 @@
+// Centralized content for the global info banner shown at the top of the docs
+// site. The banner informs users that the screenshots/visuals in the
+// documentation are pending an update to match the new platform UI, so any
+// discrepancies between the live platform and the docs are expected.
+//
+// To update the copy later: edit `bannerText` for BOTH locales and bump the
+// version suffix on `BANNER_STORAGE_KEY` so users who dismissed the previous
+// message see the new one again.
+
+// Descriptive + versioned key used by Nextra's <Banner> to persist dismissal in
+// localStorage. Changing this re-shows the banner to everyone (see FR-006).
+export const BANNER_STORAGE_KEY = 'docs-visuals-pending-platform-redesign-2026-06'
+
+// Locale-keyed banner message. Must contain an entry for every supported locale
+// (en-US, nl-NL) to satisfy bilingual parity.
+export const bannerText = {
+  'en-US':
+    "Heads up: the screenshots and visuals in this documentation are being updated to match Alkemio's new platform design. Some images may not yet reflect the latest UI.",
+  'nl-NL':
+    'Let op: de schermafbeeldingen en visuals in deze documentatie worden bijgewerkt naar het nieuwe platformontwerp van Alkemio. Sommige afbeeldingen komen mogelijk nog niet overeen met de nieuwste UI.'
+}
+
+const DEFAULT_LOCALE = 'en-US'
+
+// Returns the banner message for the given locale, falling back to the default
+// locale so the banner is never blank for a supported page.
+export function getBannerText(lang) {
+  return bannerText[lang] ?? bannerText[DEFAULT_LOCALE]
+}

--- a/app/_components/banner-content.js
+++ b/app/_components/banner-content.js
@@ -9,15 +9,15 @@
 
 // Descriptive + versioned key used by Nextra's <Banner> to persist dismissal in
 // localStorage. Changing this re-shows the banner to everyone (see FR-006).
-export const BANNER_STORAGE_KEY = 'docs-visuals-pending-platform-redesign-2026-06'
+export const BANNER_STORAGE_KEY = 'docs-visuals-pending-platform-redesign-2026-06-v2'
 
 // Locale-keyed banner message. Must contain an entry for every supported locale
 // (en-US, nl-NL) to satisfy bilingual parity.
 export const bannerText = {
   'en-US':
-    "Heads up: the screenshots and visuals in this documentation are being updated to match Alkemio's new platform design. Some images may not yet reflect the latest UI.",
+    "Heads up: the screenshots and visuals in this documentation are being updated to match Alkemio's new platform design. Some images may not yet reflect the latest version.",
   'nl-NL':
-    'Let op: de schermafbeeldingen en visuals in deze documentatie worden bijgewerkt naar het nieuwe platformontwerp van Alkemio. Sommige afbeeldingen komen mogelijk nog niet overeen met de nieuwste UI.'
+    'Let op: de schermafbeeldingen en visuals in deze documentatie worden bijgewerkt naar het nieuwe platformontwerp van Alkemio. Sommige afbeeldingen komen mogelijk nog niet overeen met de nieuwste versie.'
 }
 
 const DEFAULT_LOCALE = 'en-US'

--- a/specs/001-info-banner-pending-sync/checklists/requirements.md
+++ b/specs/001-info-banner-pending-sync/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Requirements Quality Checklist: Info banner for pending docs/platform design sync
+
+**Purpose**: Validate the completeness, clarity, and testability of the feature specification before planning.
+**Created**: 2026-06-16
+**Feature**: [spec.md](../spec.md)
+
+## Requirement Completeness
+
+- [x] CHK001 A requirement covers displaying the banner on every documentation page (FR-001, FR-003).
+- [x] CHK002 A requirement specifies the banner message content/meaning (FR-002).
+- [x] CHK003 A requirement covers dismissibility and dismissal persistence (FR-004, FR-005).
+- [x] CHK004 A requirement covers re-showing the banner when the message changes (FR-006).
+- [x] CHK005 A requirement covers bilingual rendering for both supported locales (FR-007).
+- [x] CHK006 A requirement covers iframe height accounting so the banner is not clipped (FR-009).
+
+## Requirement Clarity & Testability
+
+- [x] CHK007 Each functional requirement is independently verifiable.
+- [x] CHK008 Success criteria are measurable and technology-agnostic (SC-001..SC-005).
+- [x] CHK009 Acceptance scenarios use Given/When/Then and map to user stories.
+- [x] CHK010 Edge cases (iframe clipping, dismissal scope, message invalidation, light theme, narrow viewport) are enumerated.
+
+## Consistency with Project Constitution
+
+- [x] CHK011 Bilingual parity requirement present (Constitution Principle I → FR-007).
+- [x] CHK012 Iframe compatibility requirement present (Constitution Principle II → FR-009).
+- [x] CHK013 Build integrity captured as success criterion (Constitution Principle III → SC-004).
+- [x] CHK014 Light-theme constraint captured (Constitution Principle IV → FR-008).
+- [x] CHK015 Minimal-footprint / native-mechanism preference captured (Constitution Principle V → FR-010).
+
+## Scope & Assumptions
+
+- [x] CHK016 Out-of-scope items (optional link, dark mode) are explicitly excluded in Assumptions.
+- [x] CHK017 Open decisions are resolved as recorded assumptions/clarifications, not left ambiguous.
+
+## Notes
+
+- All items resolved during specify/clarify. The bilingual banner string is a layout-level UI string handled in code (keyed by locale), not MDX content; recorded as a clarification.

--- a/specs/001-info-banner-pending-sync/contracts/banner.md
+++ b/specs/001-info-banner-pending-sync/contracts/banner.md
@@ -1,0 +1,42 @@
+# Behavioural Contract: Global info banner
+
+**Feature**: 001-info-banner-pending-sync | **Date**: 2026-06-16
+
+This docs site has no HTTP API surface for this feature. The "contract" is the
+observable UI/behavioural contract of the global banner and the public shape of
+the banner-content module.
+
+## Module contract — `app/_components/banner-content.js`
+
+```js
+// Exports:
+export const BANNER_STORAGE_KEY: string          // descriptive + versioned key
+export const bannerText: Record<string, string>  // locale -> message
+export function getBannerText(lang: string): string  // localized text, falls back to en-US
+```
+
+- `BANNER_STORAGE_KEY` MUST be a non-empty string and MUST change when the message
+  text materially changes.
+- `bannerText` MUST contain entries for every supported locale (`en-US`, `nl-NL`).
+- `getBannerText(lang)` MUST return `bannerText[lang]` when present, otherwise the
+  `en-US` entry; it MUST never return empty/undefined for a supported locale.
+
+## UI behavioural contract — rendered banner
+
+| ID | Given | When | Then |
+|----|-------|------|------|
+| BC-1 | A fresh browser (no dismissal stored) on any docs page, `en-US` | Page renders | A banner appears at the top of the site with the `en-US` message |
+| BC-2 | Banner visible | User navigates to another page | Banner still visible (global) |
+| BC-3 | Banner visible | User clicks the close control | Banner is hidden |
+| BC-4 | Banner dismissed | User reloads or navigates | Banner stays hidden |
+| BC-5 | Page rendered in `nl-NL` | Page renders | Banner shows the Dutch message |
+| BC-6 | A dismissal exists under an OLD storage key, copy/key updated | User visits | Banner shows the new message again |
+| BC-7 | Docs embedded in platform iframe, banner present | Page renders / banner dismissed | Reported `PAGE_HEIGHT` reflects current total height; no content/banner clipped |
+| BC-8 | Forced light theme | Page renders | Banner renders legibly; no dark-mode variant |
+| BC-9 | Keyboard user | Tabs to the banner close control and presses Enter/Space | Banner is dismissed (close control is a focusable button) |
+
+## Non-goals
+
+- No backend endpoint, no analytics event, no admin toggle.
+- No link/CTA inside the banner (plain informational text only).
+- No dark-mode styling.

--- a/specs/001-info-banner-pending-sync/data-model.md
+++ b/specs/001-info-banner-pending-sync/data-model.md
@@ -1,0 +1,50 @@
+# Phase 1 Data Model: Info banner for pending docs/platform design sync
+
+**Feature**: 001-info-banner-pending-sync | **Date**: 2026-06-16
+
+This feature has no persistent server-side data. The only "data" are static,
+localized UI strings and a client-side dismissal flag managed by the framework.
+
+## Entities
+
+### BannerNotice (static configuration)
+
+The informational message rendered globally at the top of the docs site.
+
+| Field | Type | Description | Constraints |
+|-------|------|-------------|-------------|
+| `text` (per locale) | string | The user-facing banner message | Required for each supported locale (`en-US`, `nl-NL`); plain text |
+| `storageKey` | string | Identifier used to persist dismissal and to invalidate on copy change | Required; descriptive + versioned (e.g. `docs-visuals-pending-platform-redesign-2026-06`); must change when `text` materially changes |
+| `dismissible` | boolean | Whether a close control is shown | Fixed `true` |
+
+**Source of truth**: `app/_components/banner-content.js` (locale-keyed map +
+exported `storageKey`).
+
+**Localized values** (canonical):
+
+- `en-US`: "Heads up: the screenshots and visuals in this documentation are being updated to match Alkemio's new platform design. Some images may not yet reflect the latest UI."
+- `nl-NL`: "Let op: de schermafbeeldingen en visuals in deze documentatie worden bijgewerkt naar het nieuwe platformontwerp van Alkemio. Sommige afbeeldingen komen mogelijk nog niet overeen met de nieuwste UI."
+
+### BannerDismissalState (client-side, framework-managed)
+
+| Field | Type | Description | Constraints |
+|-------|------|-------------|-------------|
+| key | string | Equals `BannerNotice.storageKey` | Set in `localStorage` by Nextra `Banner` on dismiss |
+| value | truthy | Presence indicates dismissed | Managed entirely by the framework; not read/written by app code |
+
+**Lifecycle**: Absent → banner shown. User clicks close → key written → banner
+hidden on this and future loads. `storageKey` changes (new copy) → old key no
+longer matches → banner shown again.
+
+## Relationships
+
+`app/[lang]/layout.jsx` selects `BannerNotice.text[lang]` (falling back to the
+default locale) and the shared `storageKey`, and passes them to the native
+`Banner`, which owns the `BannerDismissalState`.
+
+## Validation Rules
+
+- Every supported locale MUST have a non-empty `text` entry (bilingual parity).
+- `storageKey` MUST be non-empty and MUST be revised when `text` changes (FR-006).
+- A locale with no explicit entry MUST fall back to the default locale (`en-US`)
+  so the banner is never blank.

--- a/specs/001-info-banner-pending-sync/plan.md
+++ b/specs/001-info-banner-pending-sync/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan: Info banner for pending docs/platform design sync
+
+**Branch**: `story/125-info-banner-pending-sync-docs-platform-design` | **Date**: 2026-06-16 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/001-info-banner-pending-sync/spec.md`
+
+## Summary
+
+Add a global, dismissible informational banner to the top of the Alkemio
+documentation site informing users that the screenshots/visuals are pending an
+update to match the new platform UI, so discrepancies are expected and temporary.
+Technical approach: use the documentation framework's native banner mechanism —
+the `Banner` component from `nextra/components` passed to the `banner` prop of the
+`nextra-theme-docs` `Layout` in `app/[lang]/layout.jsx`. Banner text is
+locale-aware (`en-US`, `nl-NL`), centralized in a small co-located module, and
+keyed by a descriptive/versioned `storageKey` so a future copy change re-shows it.
+
+## Technical Context
+
+**Language/Version**: JavaScript (JSX), Node.js >= 22, React 19.2
+**Primary Dependencies**: Next.js 16 (App Router), Nextra 4.6 + `nextra-theme-docs` 4.6 (already installed; `Banner` is exported from `nextra/components`)
+**Storage**: Client-side `localStorage` (banner dismissal), provided by the native `Banner` (no backend; static docs site)
+**Testing**: No unit-test harness and no separate lint/format/typecheck pipeline exist in this repo (no eslint/tsconfig; plain JSX). Validation is via `pnpm build` (next build = the repo's full static validation + Pagefind index) and manual/visual verification per quickstart. CI runs `pnpm install` + `pnpm build`.
+**Target Platform**: Static/SSR docs site served at base path `/documentation`, viewed standalone and embedded in the Alkemio platform iframe (forced light theme)
+**Project Type**: Single web project (Next.js App Router with Nextra)
+**Performance Goals**: No measurable performance impact; banner is a single small DOM node rendered at the layout level
+**Constraints**: Forced light theme only; must not clip in iframe (`PAGE_HEIGHT` messaging must include banner); bilingual parity; minimal footprint (no new dependencies)
+**Scale/Scope**: One layout edit + one small locale string module; affects all routes/locales globally
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against `.specify/memory/constitution.md` v1.0.0:
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Bilingual Content Sync | PASS | Banner string provided for both `en-US` and `nl-NL` (FR-007). It is a layout UI string, not MDX content, so it lives in code keyed by locale; Dutch working text included, subject to later Crowdin refinement (recorded as clarification). |
+| II. Iframe Compatibility | PASS | No change to `ClientProviders`; existing `ResizeObserver` on `document.body` already measures total height incl. banner; renders standalone and embedded (FR-009). |
+| III. Build Integrity | PASS | `pnpm build` + Pagefind postbuild must pass (SC-004); no new build steps. |
+| IV. Light Theme & Visual Consistency | PASS | No dark-mode variant added; banner uses native styling under forced light theme (FR-008). |
+| V. Simplicity & Minimal Footprint | PASS | Uses the framework's native `Banner`; no new dependency; one layout edit + one tiny module (FR-010). |
+
+No violations. Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-info-banner-pending-sync/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── banner.md        # Behavioural contract for the banner
+├── checklists/
+│   └── requirements.md  # Requirements quality checklist
+├── spec.md
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+app/
+├── [lang]/
+│   └── layout.jsx           # EDIT: pass <Banner> to Layout banner prop, locale-aware text
+└── _components/
+    └── banner-content.js    # NEW: centralized locale-keyed banner strings + storage key
+```
+
+**Structure Decision**: Single Next.js/Nextra web project. The banner is wired at
+the locale layout (`app/[lang]/layout.jsx`), which already receives the resolved
+`lang` param, making it the natural place to choose the localized message. The
+message strings and the versioned storage key are extracted to a small co-located
+module `app/_components/banner-content.js` so copy is centralized and editable in
+one place (supports FR-006 key/text coupling and easy future updates). No new
+directories or dependencies are introduced.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.
+
+## Cross-Artifact Analysis (speckit-analyze)
+
+Read-only consistency check of spec.md ↔ plan.md ↔ tasks.md ↔ codebase ↔ constitution.
+
+**Iteration 1 findings**:
+- **F1 (resolved)**: tasks/plan referenced a lint/format/typecheck pipeline that
+  does not exist in this repo (no eslint config, no tsconfig; plain JSX). CI and
+  the repo's only validation is `pnpm build`. Amended T008 and the plan's Testing
+  context to make `pnpm build` the sole exit gate.
+- Coverage verified: every FR maps to a task (FR-001/003/010→T003; FR-002→T003;
+  FR-004/005/006→T004; FR-007→T002/T005; FR-008/011→T007; FR-009→T006); every SC
+  maps (SC-001/002/003→T009 quickstart; SC-004→T008; SC-005→T006); all three user
+  stories have phases; constitution gates all PASS.
+
+**Iteration 2 findings**: 0. After F1 amendment, artifacts are mutually
+consistent and consistent with the codebase and constitution. Analyze loop
+terminates clean (2 iterations).

--- a/specs/001-info-banner-pending-sync/quickstart.md
+++ b/specs/001-info-banner-pending-sync/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart: Info banner for pending docs/platform design sync
+
+**Feature**: 001-info-banner-pending-sync | **Date**: 2026-06-16
+
+## Prerequisites
+
+- Node.js >= 22, pnpm >= 9 (repo uses `pnpm@10.17.1`)
+- From the worktree root: `pnpm install`
+
+## What was added
+
+1. `app/_components/banner-content.js` — locale-keyed banner strings + versioned
+   `BANNER_STORAGE_KEY` + `getBannerText(lang)` helper.
+2. `app/[lang]/layout.jsx` — imports `Banner` from `nextra/components` and the
+   banner content, and passes `banner={<Banner storageKey={...}>{getBannerText(lang)}</Banner>}`
+   to the `nextra-theme-docs` `Layout`.
+
+## Run locally
+
+```bash
+pnpm dev      # http://localhost:3010/documentation  (search disabled in dev)
+```
+
+Open the site. Expected: a banner across the top of the page with the
+"screenshots/visuals are being updated" message. Click the close (×) control →
+banner disappears. Reload → banner stays hidden. Switch the locale to Nederlands
+→ banner text shows in Dutch.
+
+To reset the dismissed state during testing, clear the `localStorage` key
+`docs-visuals-pending-platform-redesign-2026-06` (DevTools → Application →
+Local Storage) and reload.
+
+## Verify the production build (exit gate)
+
+```bash
+pnpm build    # next build + pagefind postbuild — MUST succeed (SC-004)
+pnpm start    # http://localhost:3010/documentation (search works post-build)
+```
+
+## Verify iframe height (FR-009 / BC-7)
+
+The banner is part of the document flow; `ClientProviders` observes `document.body`
+and reports total height via the `PAGE_HEIGHT` postMessage. With the banner shown
+then dismissed, the resize observer fires and a fresh height is posted, so the
+embedding iframe is sized correctly and nothing is clipped. No code change needed
+in `ClientProviders` — confirm by inspecting that dismissing the banner triggers a
+new `PAGE_HEIGHT` message (e.g. via a console log or the parent frame).
+
+## Updating the copy later
+
+Edit `bannerText` in `app/_components/banner-content.js` for both locales, and
+bump the version suffix on `BANNER_STORAGE_KEY` so previously-dismissed users see
+the new message.

--- a/specs/001-info-banner-pending-sync/research.md
+++ b/specs/001-info-banner-pending-sync/research.md
@@ -1,0 +1,76 @@
+# Phase 0 Research: Info banner for pending docs/platform design sync
+
+**Feature**: 001-info-banner-pending-sync | **Date**: 2026-06-16
+
+## Decisions
+
+### D1 — Banner mechanism: Nextra native `Banner` via `Layout` `banner` prop
+
+- **Decision**: Use the `Banner` component exported from `nextra/components`,
+  passed to the `banner` prop of the `nextra-theme-docs` `Layout`.
+- **Rationale**: It is the framework-native, supported way to render a top-of-site
+  banner. Confirmed present in the installed packages:
+  - `node_modules/nextra/dist/client/components/index.js` exports `Banner`.
+  - `nextra-theme-docs` schema (`dist/schemas.js`) documents the `banner` prop as a
+    "Rendered `<Banner>` component" and the layout types declare `banner?: React.ReactNode`.
+  - `Banner` is dismissible by default (`dismissible = true`) and persists dismissal
+    in `localStorage` under a `storageKey` (default `nextra-banner`).
+- **Alternatives considered**:
+  - *Custom React component + custom CSS in `styles.css`*: rejected — more code,
+    duplicates dismissal/persistence logic the framework already provides, violates
+    Constitution Principle V (minimal footprint).
+  - *MDX `<Callout>` inside each page*: rejected — not global, would require editing
+    every page in both locales, no top-of-site placement, no dismissal persistence.
+
+### D2 — Placement: locale layout (`app/[lang]/layout.jsx`)
+
+- **Decision**: Wire the banner in `app/[lang]/layout.jsx`, which already awaits
+  `params` and has `lang` available.
+- **Rationale**: This layout wraps all routes for a locale and already constructs
+  `navbar`/`footer` for `<Layout>`. Adding the `banner` prop here makes the banner
+  global and lets us pick the localized string from the resolved `lang`.
+- **Alternatives considered**: Root `app/layout.jsx` — rejected, it is minimal and
+  does not render the Nextra `Layout` nor have the locale.
+
+### D3 — Localization of the banner string
+
+- **Decision**: Store banner strings in a small co-located module
+  `app/_components/banner-content.js`, keyed by locale (`en-US`, `nl-NL`), plus a
+  single exported versioned `storageKey`.
+- **Rationale**: The banner text is a layout-level UI string, not page (MDX)
+  content. Crowdin governs MDX content translation; for a layout chrome string the
+  established React i18n pattern is a code map. Centralizing satisfies bilingual
+  parity (Constitution I) and couples text↔key for FR-006.
+- **Alternatives considered**: Inline ternary in the layout — rejected, scatters
+  copy and the key; harder to update and to keep both locales in sync.
+
+### D4 — Storage key strategy (re-show on copy change)
+
+- **Decision**: Use a descriptive, versioned key, e.g.
+  `docs-visuals-pending-platform-redesign-2026-06`. Bump the suffix when the copy
+  materially changes.
+- **Rationale**: Satisfies FR-006 — users who dismissed an old message see a new
+  one. Matches Nextra's documented best practice ("always use a descriptive key
+  for the current text").
+
+### D5 — Iframe height handling
+
+- **Decision**: No change to `ClientProviders`.
+- **Rationale**: `ClientProviders` observes `document.body` with a `ResizeObserver`
+  and reports `document.documentElement.scrollHeight || document.body.scrollHeight`.
+  The banner is part of the document flow at the top, so total height already
+  includes it; dismissing the banner triggers a resize → a fresh `PAGE_HEIGHT`.
+  No additional integration code is needed (FR-009). Verify in quickstart.
+
+### D6 — Theme & accessibility
+
+- **Decision**: Rely on native `Banner` styling under forced light theme; do not
+  add dark-mode styles. Keep default dismiss `<button>` (keyboard-accessible).
+- **Rationale**: Constitution IV (light-only) and FR-011 (a11y). The native close
+  control is a real button with an icon; banner text contrast on the native dark
+  banner background is sufficient. If contrast/visual needs tuning for the light
+  brand, a minimal `className`/CSS override may be applied without adding dark mode.
+
+## Open Questions
+
+None. All clarifications resolved in spec.md (2 clarify iterations, 0 remaining).

--- a/specs/001-info-banner-pending-sync/spec.md
+++ b/specs/001-info-banner-pending-sync/spec.md
@@ -1,0 +1,160 @@
+# Feature Specification: Info banner for pending synchronisation of docs with latest platform design
+
+**Feature Branch**: `story/125-info-banner-pending-sync-docs-platform-design`
+**Created**: 2026-06-16
+**Status**: Clarified
+**Input**: User description: "Info banner for the pending synchronisation of the docs with the latest platform design. As a user I want to be prompted that the documentation is not up-to-date with the latest platform design, so the discrepancies between the platform and the docs site are expected. Acceptance criteria: An info banner on top of the docs site informing the users that the visuals in the docs site are pending update to match the new platform UI." (GitHub story alkem-io/documentation#125)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reader is informed the docs visuals are pending update (Priority: P1)
+
+A user opens any page of the Alkemio documentation site (standalone or embedded
+in the platform iframe). Before or while reading, they see a clearly-styled
+informational banner at the top of the site stating that the visuals/screenshots
+in the documentation are pending an update to match the new platform UI, so any
+discrepancies between what they see in the platform and what is shown in the docs
+are expected and temporary.
+
+**Why this priority**: This is the entire purpose of the story. Without the
+banner, users encountering visual mismatches between the live platform and the
+docs may conclude the docs are wrong or that they are using the product
+incorrectly, eroding trust. The banner sets expectations up front. It is the MVP.
+
+**Independent Test**: Load any documentation page (e.g. the home page) in the
+default `en-US` locale and confirm an info banner appears at the top of the site
+with the expected message. This single slice delivers the full user value.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user navigates to any documentation page in `en-US`, **When** the page renders, **Then** an info banner is displayed at the top of the site stating the docs visuals are pending update to match the new platform UI.
+2. **Given** a user navigates between multiple documentation pages, **When** each page renders, **Then** the banner remains visible at the top on every page (it is global, not page-specific) until dismissed.
+3. **Given** the documentation is embedded in the Alkemio platform iframe, **When** a page renders, **Then** the banner is displayed and the iframe height messaging (`PAGE_HEIGHT`) accounts for the banner so no content is clipped.
+
+### User Story 2 - Reader can dismiss the banner (Priority: P2)
+
+A returning or focused user who has already acknowledged the notice can dismiss
+the banner so it no longer occupies vertical space on subsequent reading, and the
+dismissal is remembered across navigation and visits.
+
+**Why this priority**: Reduces friction for repeat readers and keeps the reading
+surface clean once the message has been seen. Valuable but secondary to simply
+showing the message; the native banner mechanism provides this for free.
+
+**Independent Test**: Display the banner, click its dismiss control, confirm it
+disappears, then navigate to another page / reload and confirm it stays hidden.
+
+**Acceptance Scenarios**:
+
+1. **Given** the banner is visible, **When** the user clicks the dismiss (close) control, **Then** the banner is hidden.
+2. **Given** the user has dismissed the banner, **When** they navigate to another page or reload the site, **Then** the banner remains hidden.
+3. **Given** the banner message text is later changed (new wording / new key), **When** a user who previously dismissed the old banner visits, **Then** the new banner is shown again (dismissal does not suppress a materially new notice).
+
+### User Story 3 - Dutch-speaking reader sees the notice in their language (Priority: P3)
+
+A user browsing the documentation in the Dutch (`nl-NL`) locale sees the same
+informational banner with the message presented in Dutch.
+
+**Why this priority**: The platform serves Dutch and English audiences and the
+constitution mandates bilingual content parity. Important for completeness but
+the core value (informing the user) is already delivered for the default locale.
+
+**Independent Test**: Switch the locale to `nl-NL` (or load an `nl-NL` URL) and
+confirm the banner appears with the Dutch translation of the message.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user views the documentation in `nl-NL`, **When** any page renders, **Then** the banner is displayed with the message in Dutch.
+2. **Given** a user switches locale from `en-US` to `nl-NL`, **When** the locale changes, **Then** the banner message reflects the active locale.
+
+### Edge Cases
+
+- **No clipping in iframe**: When embedded, the banner adds height; the page-height message sent to the parent must include the banner so the iframe is not too short and the banner is not cut off.
+- **Dismissal persistence boundary**: Dismissal is per-browser (client storage). A user on a different browser/device sees the banner again — this is expected and acceptable.
+- **Message update invalidation**: If the wording changes, previously-dismissed users must see the updated banner; this requires a versioned/descriptive storage key tied to the current message.
+- **Light-theme only**: The banner must render correctly under the forced light theme; no dark-mode variant is needed.
+- **Standalone vs iframe**: The banner must render identically whether the docs are viewed standalone (`not-in-iframe`) or embedded.
+- **Long message / small viewport**: On narrow viewports the banner text must wrap and remain readable without breaking layout.
+- **Link (optional)**: If the message includes a link, it must be keyboard-accessible and open appropriately; if no link is required, the banner is plain text.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The documentation site MUST display an informational banner at the top of the site on every documentation page.
+- **FR-002**: The banner MUST inform users that the visuals/screenshots in the documentation are pending update to match the new platform UI, and that discrepancies between the platform and the docs are expected and temporary.
+- **FR-003**: The banner MUST be global (rendered once at the layout level) and appear consistently across all pages and routes.
+- **FR-004**: The banner MUST be dismissible by the user via a visible close control.
+- **FR-005**: Once dismissed, the banner MUST remain hidden across page navigation and subsequent visits within the same browser (persisted via client-side storage).
+- **FR-006**: The banner's persistence key MUST be tied to the current message so that a future change to the message re-shows the banner to users who dismissed the previous one.
+- **FR-007**: The banner message MUST be available in both supported locales (`en-US` and `nl-NL`) and MUST render in the locale active for the current page.
+- **FR-008**: The banner MUST render correctly under the site's forced light theme and MUST NOT introduce a dark-mode variant.
+- **FR-009**: When the documentation is embedded in the Alkemio platform iframe, the banner MUST be accounted for in the `PAGE_HEIGHT` message so no content (including the banner) is clipped.
+- **FR-010**: The banner MUST be implemented using the documentation framework's native banner mechanism (Nextra `Banner` via the theme `Layout` `banner` prop), avoiding a bespoke component where the native one suffices.
+- **FR-011**: The banner MUST be accessible: dismiss control reachable by keyboard, message readable by assistive technology, and text legible (sufficient contrast) on the light theme.
+
+### Key Entities *(include if feature involves data)*
+
+- **Banner notice**: The informational message shown to users. Attributes: localized text (`en-US`, `nl-NL`), a descriptive/versioned storage key identifying the current message, dismissible flag (true). Relationship: rendered globally by the documentation layout.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On a fresh browser session, 100% of documentation pages (any route, default locale) display the info banner at the top of the site on first render.
+- **SC-002**: A user can dismiss the banner in a single action, and after dismissal the banner does not reappear on any page within the same browser session or on reload (0 reappearances).
+- **SC-003**: The banner message is presented in the correct language for both supported locales (`en-US` and `nl-NL`) — verifiable by loading a page in each locale.
+- **SC-004**: The production build (`pnpm build`) and Pagefind index generation complete successfully with the banner in place (0 build errors).
+- **SC-005**: When embedded in the platform iframe, no documentation content or the banner itself is clipped — the iframe height reflects the banner (verifiable by inspecting that the reported page height includes the banner).
+
+## Assumptions
+
+- The documentation framework is Nextra 4 with `nextra-theme-docs`, whose `Layout` accepts a `banner` prop and exposes a dismissible `Banner` component from `nextra/components` (confirmed by inspecting installed packages). This native mechanism is the chosen implementation per FR-010.
+- Per the constitution, Dutch translations normally flow through Crowdin; however, the banner text is a layout-level UI string rather than MDX content. To satisfy bilingual parity (FR-007) within this single repo PR, the localized banner strings are defined in code keyed by locale, alongside the existing localized layout strings, with the canonical English text authored here and the Dutch text provided as the working translation (subject to later Crowdin refinement). This is the optimal in-repo resolution and is recorded as a clarification.
+- The banner is informational only (no destructive or required action) and contains plain text; an optional link is not required by the acceptance criteria and is therefore omitted to keep the footprint minimal (constitution principle V).
+- The exact final marketing copy may be refined by content owners; the spec fixes the meaning and the implementation centralizes the text so copy can be updated in one place. Canonical wording chosen below.
+- Forced light theme remains; no dark-mode styling is added.
+
+## Clarifications
+
+### Session 2026-06-16 (iteration 1)
+
+Ambiguities surfaced across taxonomy categories (functional scope, data/state,
+interaction, non-functional, integration, i18n, copy). Each resolved by decision
+per YOLO rules, consistent with repo conventions and the constitution.
+
+- **Q (Functional scope): Should the banner be dismissible or permanently shown until the docs are updated?**
+  **A**: Dismissible. Rationale: the Nextra native `Banner` is dismissible by default and this is the established UX pattern; a permanent un-dismissable bar is more intrusive and not requested. Re-show on message change handles the "still relevant" concern. (→ FR-004, FR-006)
+
+- **Q (Data/state): Where is the dismissal state stored and what is its scope?**
+  **A**: Client-side `localStorage` (Nextra `Banner` default), scoped per browser, keyed by a descriptive/versioned `storageKey`. Rationale: no backend exists in this static docs site; matches framework default. (→ FR-005, FR-006)
+
+- **Q (Copy): What is the canonical English banner text?**
+  **A**: "Heads up: the screenshots and visuals in this documentation are being updated to match Alkemio's new platform design. Some images may not yet reflect the latest UI." Rationale: states the discrepancy is expected and temporary per the story's user need; centralized in code for easy copy edits. (→ FR-002)
+
+- **Q (i18n): How is the Dutch text provided given Crowdin normally owns translations?**
+  **A**: The banner is a layout-level UI string, not MDX content, so it is defined in code keyed by locale (alongside existing localized layout strings). Canonical Dutch working text: "Let op: de schermafbeeldingen en visuals in deze documentatie worden bijgewerkt naar het nieuwe platformontwerp van Alkemio. Sommige afbeeldingen komen mogelijk nog niet overeen met de nieuwste UI." Subject to later Crowdin refinement. Rationale: satisfies bilingual parity (Constitution I) within one PR. (→ FR-007)
+
+- **Q (Integration / non-functional): Does the banner break iframe height messaging?**
+  **A**: No new handling required. The existing `ResizeObserver` on `document.body` in `ClientProviders` already measures total document height (which includes the banner) and the banner is sticky at the top within the document flow, so `PAGE_HEIGHT` already accounts for it. We verify rather than add code. (→ FR-009, SC-005)
+
+- **Q (Interaction / placement): Where exactly does the banner render — per page or globally?**
+  **A**: Globally, via the `banner` prop on the `nextra-theme-docs` `Layout` in `app/[lang]/layout.jsx`, so it appears once above the navbar on all routes and locales. (→ FR-003, FR-010)
+
+- **Q (Non-functional / theme + a11y): Any theme or accessibility constraints?**
+  **A**: Must work under forced light theme (no dark variant) and the dismiss control must be keyboard-accessible with legible contrast. The native `Banner` close button is a real `<button>` (keyboard-accessible); text uses the framework's banner styling which is legible. (→ FR-008, FR-011)
+
+**Result of iteration 1**: 7 ambiguities resolved.
+
+### Session 2026-06-16 (iteration 2)
+
+Re-scanned all taxonomy categories against the updated spec. No new ambiguities
+found: scope, state, copy (both locales), integration, placement, theme, and
+accessibility are all now decided and reflected in the requirements. Clarify
+loop terminates clean.
+
+**Result of iteration 2**: 0 new ambiguities. Loop complete (2 iterations).
+
+### Story mapping
+
+- GitHub story: `alkem-io/documentation#125` (this is the source story; the spec is its single-repo SDD artifact). The PR will reference `Closes #125`.

--- a/specs/001-info-banner-pending-sync/tasks.md
+++ b/specs/001-info-banner-pending-sync/tasks.md
@@ -1,0 +1,144 @@
+---
+description: "Task list for feature: Info banner for pending docs/platform design sync"
+---
+
+# Tasks: Info banner for pending docs/platform design sync
+
+**Input**: Design documents from `/specs/001-info-banner-pending-sync/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/banner.md
+
+**Tests**: This repo has no unit-test harness (validation is via `pnpm build` +
+manual/visual verification per quickstart). No test tasks are included; the spec
+did not request automated tests. Verification is captured as build + manual gates.
+
+**Organization**: Tasks grouped by user story (US1 P1, US2 P2, US3 P3) for
+independent implementability.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 / US2 / US3 (or none for shared phases)
+
+## Path Conventions
+
+Single Next.js/Nextra web project; paths are relative to the worktree root.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the framework banner mechanism is available before wiring it.
+
+- [X] T001 Verify `Banner` is exported from `nextra/components` and the `banner` prop is accepted by `nextra-theme-docs` `Layout` in the installed versions (inspect `node_modules/nextra/dist/client/components/index.js` and `node_modules/nextra-theme-docs/dist/types.generated.d.mts`). No dependency changes expected (FR-010).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Centralized banner content module that all stories consume.
+
+**⚠️ CRITICAL**: US1/US2/US3 all depend on this module.
+
+- [X] T002 Create `app/_components/banner-content.js` exporting `BANNER_STORAGE_KEY` (descriptive + versioned, e.g. `docs-visuals-pending-platform-redesign-2026-06`), `bannerText` (locale map for `en-US` and `nl-NL`), and `getBannerText(lang)` with fallback to `en-US` (per data-model.md / contracts/banner.md). Acceptance: module exports match the contract; both locales non-empty; fallback returns `en-US` for unknown locale.
+
+**Checkpoint**: Banner content available for layout wiring.
+
+---
+
+## Phase 3: User Story 1 - Reader is informed visuals are pending (Priority: P1) 🎯 MVP
+
+**Goal**: A global info banner shows the pending-visuals message at the top of every page in `en-US`.
+
+**Independent Test**: Load any page in `en-US`; banner appears at top with the message.
+
+### Implementation for User Story 1
+
+- [X] T003 [US1] Edit `app/[lang]/layout.jsx`: import `Banner` from `nextra/components` and `getBannerText` + `BANNER_STORAGE_KEY` from `app/_components/banner-content.js`; build a `banner` element `<Banner storageKey={BANNER_STORAGE_KEY}>{getBannerText(lang)}</Banner>` and pass it to `<Layout banner={banner} ...>`. Acceptance: banner renders globally above the navbar on all routes (FR-001, FR-003, FR-010); message matches FR-002.
+
+**Checkpoint**: MVP — banner visible site-wide in the default locale.
+
+---
+
+## Phase 4: User Story 2 - Reader can dismiss the banner (Priority: P2)
+
+**Goal**: Banner is dismissible and dismissal persists; re-shows when the message changes.
+
+**Independent Test**: Dismiss the banner → it hides → reload/navigate → stays hidden.
+
+### Implementation for User Story 2
+
+- [X] T004 [US2] Confirm the native `Banner` is dismissible (default `dismissible=true`) and persists via `BANNER_STORAGE_KEY` in `localStorage`; ensure the key passed in T003 is the versioned key from T002 so a future copy change re-shows the banner (FR-004, FR-005, FR-006). No extra code beyond passing `storageKey`. Acceptance: close control hides banner; dismissal survives reload; changing the key re-shows.
+
+**Checkpoint**: US1 + US2 functional.
+
+---
+
+## Phase 5: User Story 3 - Dutch reader sees the notice in Dutch (Priority: P3)
+
+**Goal**: Banner message renders in Dutch for `nl-NL`.
+
+**Independent Test**: Load an `nl-NL` page / switch locale; banner shows Dutch text.
+
+### Implementation for User Story 3
+
+- [X] T005 [US3] Ensure the `nl-NL` entry exists in `bannerText` (added in T002) and that `app/[lang]/layout.jsx` selects text via `getBannerText(lang)` using the resolved `lang` param (FR-007). Acceptance: `nl-NL` pages show the Dutch message; `en-US` unchanged.
+
+**Checkpoint**: All stories independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T006 [P] Verify iframe height: confirm `app/_components/ClientProviders.jsx` needs no change — the `ResizeObserver` on `document.body` already reports total height incl. the banner, and dismissing fires a new `PAGE_HEIGHT` (FR-009, SC-005, BC-7). Document the verification in the PR.
+- [X] T007 [P] Verify light-theme rendering and accessibility: banner legible under forced light theme (no dark variant), close control keyboard-focusable (FR-008, FR-011, BC-8, BC-9). Apply a minimal `className` only if contrast needs tuning.
+- [X] T008 Run exit gate: `pnpm build` (incl. Pagefind postbuild) succeeds with the banner in place (SC-004). NOTE: this repo has no separate lint/format/typecheck pipeline (no eslint/tsconfig; plain JSX); `pnpm build` (next build) is the repo's full validation, matching CI which runs `pnpm install` + `pnpm build`.
+- [X] T009 Run quickstart.md validation (banner shows, dismiss persists, locale switch shows Dutch).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1) → no deps.
+- Foundational (Phase 2) → depends on Setup; BLOCKS all user stories.
+- User Stories (Phases 3–5) → depend on Foundational (T002). US1/US2/US3 all touch
+  the same two files (`layout.jsx`, `banner-content.js`), so they are effectively
+  delivered together in this small feature rather than in parallel.
+- Polish (Phase 6) → after user stories.
+
+### Within Each User Story
+
+- T002 (content module) before T003 (layout wiring).
+- T003 before T004/T005 (they refine the same wiring).
+
+### Parallel Opportunities
+
+- T006 and T007 are independent verification tasks ([P]).
+- Because US1–US3 modify the same two files, their implementation tasks are NOT
+  parallelizable across each other; they are sequenced T003 → T004 → T005.
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. T001 (Setup) → T002 (Foundational) → T003 (US1). STOP and validate banner shows in `en-US`.
+
+### Incremental Delivery
+
+1. Setup + Foundational → ready.
+2. US1 (T003) → MVP (banner visible).
+3. US2 (T004) → dismissible + persistent.
+4. US3 (T005) → Dutch.
+5. Polish (T006–T009) → verify iframe/a11y/build, run quickstart.
+
+---
+
+## Notes
+
+- [P] = different files, no dependencies.
+- No automated test tasks: repo has no test runner; gates are `pnpm build` + manual.
+- Commit after each logical group (content module; layout wiring; verification).
+- Keep the working tree green between tasks (`pnpm build` must pass).

--- a/styles.css
+++ b/styles.css
@@ -41,3 +41,10 @@ button[title*="Claude"] {
 aside > div.nextra-scrollbar + div {
     display: none !important;
 }
+
+/* Info banner: override Nextra's default black background with a pale-yellow
+   warning style (tailwind/shadcn warning colors: yellow-100 bg, yellow-800 text). */
+.nextra-banner {
+    background: #fef9c3 !important;
+    color: #854d0e !important;
+}


### PR DESCRIPTION
## Summary

Adds a global, dismissible, locale-aware info banner at the top of every documentation page, informing users that the screenshots/visuals in the docs are pending an update to match Alkemio's new platform design — so discrepancies between the live platform and the docs are expected and temporary.

Implements story **#125** via the strict SpecKit SDD flow.

## What changed

- **`app/_components/banner-content.js`** (new) — centralizes the banner copy for both locales (`en-US`, `nl-NL`), a descriptive + versioned `BANNER_STORAGE_KEY`, and `getBannerText(lang)` with `en-US` fallback. Bumping the key re-shows the banner after a future copy change.
- **`app/[lang]/layout.jsx`** — wires Nextra's native `<Banner>` (from `nextra/components`) into the `nextra-theme-docs` `Layout` via the `banner` prop, so it renders once globally above the navbar across all routes and locales. Native banner is dismissible and persists dismissal in `localStorage`.

## Acceptance criteria

- [x] Info banner across the top of the docs site stating the visuals are pending update to match the new platform UI (FR-001/002/003).
- [x] Dismissible, with dismissal persisted across navigation and reload (FR-004/005).
- [x] Versioned storage key re-shows the banner when the copy changes (FR-006).
- [x] Localized in both `en-US` and `nl-NL` (FR-007).
- [x] Renders under the forced light theme; no dark-mode variant (FR-008).
- [x] Iframe `PAGE_HEIGHT` already accounts for the banner via the existing `ResizeObserver` on `document.body` — verified, no change needed (FR-009).
- [x] Accessible: native `<Banner>` close control is a focusable `<button>` (FR-011).

## SDD artifacts

Full SpecKit set under [`specs/001-info-banner-pending-sync/`](specs/001-info-banner-pending-sync/): `spec.md`, `plan.md`, `tasks.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/banner.md`, `checklists/requirements.md`.

- **Clarify loop**: 2 iterations (7 ambiguities resolved in iteration 1; 0 new in iteration 2 → clean pass).
- **Analyze loop**: converged to 0 findings.

## Exit gates

- `pnpm install --frozen-lockfile` — pass (lockfile up to date).
- `pnpm build` (`next build` + Pagefind postbuild) — pass, exit 0, 0 hard errors; both locales indexed (73 pages). This is the repo's full CI validation; there is no separate lint/typecheck pipeline (matches Travis CI: `pnpm install` + `pnpm build`).

Closes alkem-io/documentation#125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global, dismissible documentation info banner with English and Dutch localization.
  * Banner dismissal persists across navigation and sessions via a versioned local storage key, allowing updated copy to re-display the notice.
  * Ensures banner UI works well in embedded/iframe contexts and includes accessible close controls.
* **Documentation**
  * Added comprehensive feature specs and supporting guides (requirements, contract, plan, quickstart, research, tasks, and related docs).
* **Style**
  * Updated banner styling to a pale-yellow warning look with improved text contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->