### PR TITLE
ci(027): move CI off legacy arc-runner-set to hosted (workspace#027-arc-v3-runner-migration)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## workspace#027-arc-v3-runner-migration — documentation (C-11 audit-gap, all-hosted)

Moves this repo's CI off the legacy org-wide `arc-runner-set` to `ubuntu-latest` (ci-build). Discovered in the 2026-07-23 runner inventory (answering "where is the legacy App used") — **not** in the original council candidate set.

**Why it matters:** this is a **public** repo whose `pull_request` jobs execute **untrusted fork code on the unhardened legacy lane** — the exact live R-2 exposure that motivated 027, missed for this repo (same class as notifications / C-10).

**Also a prerequisite for runbook H1:** the legacy GitHub App `2938395` can only be deleted once every `arc-runner-set` consumer is off it.

**Verified:** routing checker PASS (zero self-hosted selectors remain); YAML parse clean. ✅ All-hosted — may merge independently of the wave-1 lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration build environment to use GitHub’s standard Ubuntu runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->