### PR TITLE
feat(036): distroless runtime image + hardened securityContext

### DIFF
--- a/.docker/distroless-image-smoke.sh
+++ b/.docker/distroless-image-smoke.sh
@@ -63,13 +63,27 @@ CMD_JSON="$(docker inspect "$IMAGE" --format '{{json .Config.Cmd}}')"
   fail "expected CMD [\"server.js\"] (Next standalone), got $CMD_JSON — note CMD [\"pnpm\",\"run\",\"start\"] can never work: distroless has no shell and no pnpm"
 pass "CMD is [\"server.js\"]"
 
-# --- 3. US1-AS2: no shell / package manager --------------------------------
-for bin in /bin/sh /bin/bash sh bash apk apt apt-get npm pnpm yarn; do
-  if docker run --rm --entrypoint "$bin" "$IMAGE" --version >/dev/null 2>&1; then
-    fail "expected '$bin' to be absent/unexecutable, but it ran"
-  fi
-done
-pass "no shell / package manager / npm / pnpm is executable"
+# --- no shell / no package manager -----------------------------------------
+# Probe for EXISTENCE on the filesystem, not exit status. A bare `docker run
+# --entrypoint apk <img>` exits non-zero on an image that HAS a working apk
+# (apk with no args is a usage error), so an exit-status test reports present
+# binaries as absent — it has no detection power. lstat (not existsSync) so a
+# dangling symlink still counts as a hit; Google's :debug variants put the
+# shell at /busybox/sh -> /busybox/busybox.
+FORBIDDEN="$(run_node -e "
+const fs = require('fs');
+const paths = [
+  '/bin/sh','/bin/bash','/usr/bin/sh','/usr/bin/bash',
+  '/busybox/sh','/busybox/busybox','/bin/busybox','/usr/bin/busybox',
+  '/sbin/apk','/usr/bin/apk','/usr/bin/apt','/usr/bin/apt-get','/usr/bin/dpkg',
+  '/usr/local/bin/npm','/usr/local/bin/npx','/usr/local/bin/yarn','/usr/local/bin/pnpm',
+  '/usr/bin/npm','/usr/bin/yarn','/usr/bin/pnpm',
+];
+const hits = paths.filter(p => { try { fs.lstatSync(p); return true; } catch { return false; } });
+console.log(hits.join(','));
+")"
+[ -z "$FORBIDDEN" ] || fail "shell/package-manager present in runtime image: $FORBIDDEN"
+pass "no shell / package manager present on the filesystem"
 
 # --- 4. US1-AS3: no sources, no build tooling in the runtime ---------------
 for path in app content components proxy.js mdx-components.js styles.css pnpm-lock.yaml; do

--- a/.docker/distroless-image-smoke.sh
+++ b/.docker/distroless-image-smoke.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# workspace#036-distroless-wave-1 — persisted regression for `documentation`.
+#
+# This repo's CI runs only `pnpm install` + `pnpm run build` — there is no
+# lint job and no test job. This harness is therefore the ONLY behavioural
+# gate the repository has, and it is written accordingly: it asserts both the
+# image-hardening contract AND the four site behaviours that gates DOC-4/DOC-5
+# established, so a future change cannot silently regress either.
+#
+# Asserted (DOC-10):
+#   1. US1-AS1  — image declares UID 65532, and the process really runs as it
+#   2.           — CMD is ["server.js"] on the distroless node ENTRYPOINT
+#   3. US1-AS2  — no shell, no package manager, no pnpm/npm reachable
+#   4. US1-AS3  — no source tree, no pnpm/pagefind in the runtime node_modules
+#   5. US2-AS1  — no floating FROM in the Dockerfile; both stages digest-pinned
+#   6. US7-AS1/2/3 — live HTTP: 200 under the /documentation basePath, locale
+#                    redirect, NEXT_LOCALE honoured, pagefind index served
+#                    (the persisted D1/D2 regression)
+#   7. NODE_ENV=dev injection (four of five environments inject it via the
+#      alkemio-config ConfigMap and envFrom overrides Dockerfile ENV) does not
+#      degrade the standalone server
+#   8. Emits IMAGE_DIGEST= / IMAGE_SIZE_BYTES= for mechanical evidence (US5-AS3)
+#
+# Usage: .docker/distroless-image-smoke.sh <image[:tag]>
+set -euo pipefail
+
+IMAGE="${1:?usage: distroless-image-smoke.sh <image[:tag]>}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOCKERFILE="$REPO_ROOT/Dockerfile"
+CONTAINER="doc-smoke-$$"
+HOST_PORT="${SMOKE_PORT:-31010}"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+cleanup() { docker rm -f "$CONTAINER" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+run_node() { docker run --rm --entrypoint /nodejs/bin/node "$IMAGE" "$@"; }
+
+echo "== distroless-image-smoke: $IMAGE =="
+
+# --- 1. US1-AS1: declared user --------------------------------------------
+USER_ID="$(docker inspect "$IMAGE" --format '{{.Config.User}}')"
+[ "$USER_ID" = "65532" ] || [ "$USER_ID" = "nonroot" ] ||
+  fail "expected image user 65532/nonroot, got '$USER_ID' (an empty value means ROOT, and the hardened securityContext's runAsNonRoot would fail admission before start)"
+pass "image declares user '$USER_ID'"
+
+# The kubelet checks the declared user, but only the running process proves it.
+ACTUAL_UID="$(run_node -e "console.log(process.getuid()+':'+process.getgid())")"
+[ "$ACTUAL_UID" = "65532:65532" ] ||
+  fail "expected process uid:gid 65532:65532, got '$ACTUAL_UID'"
+pass "process really runs as uid:gid $ACTUAL_UID"
+
+# --- 2. entrypoint + CMD ---------------------------------------------------
+ENTRYPOINT_JSON="$(docker inspect "$IMAGE" --format '{{json .Config.Entrypoint}}')"
+echo "$ENTRYPOINT_JSON" | grep -q '/nodejs/bin/node' ||
+  fail "expected the distroless node entrypoint, got $ENTRYPOINT_JSON"
+pass "entrypoint is the distroless node binary"
+
+CMD_JSON="$(docker inspect "$IMAGE" --format '{{json .Config.Cmd}}')"
+[ "$CMD_JSON" = '["server.js"]' ] ||
+  fail "expected CMD [\"server.js\"] (Next standalone), got $CMD_JSON — note CMD [\"pnpm\",\"run\",\"start\"] can never work: distroless has no shell and no pnpm"
+pass "CMD is [\"server.js\"]"
+
+# --- 3. US1-AS2: no shell / package manager --------------------------------
+for bin in /bin/sh /bin/bash sh bash apk apt apt-get npm pnpm yarn; do
+  if docker run --rm --entrypoint "$bin" "$IMAGE" --version >/dev/null 2>&1; then
+    fail "expected '$bin' to be absent/unexecutable, but it ran"
+  fi
+done
+pass "no shell / package manager / npm / pnpm is executable"
+
+# --- 4. US1-AS3: no sources, no build tooling in the runtime ---------------
+for path in app content components proxy.js mdx-components.js styles.css pnpm-lock.yaml; do
+  EXISTS="$(run_node -e "console.log(require('fs').existsSync('/app/$path'))")"
+  [ "$EXISTS" = "false" ] || fail "expected '/app/$path' to be absent from the runtime image"
+done
+pass "no source tree in the runtime image (Next standalone traced output only)"
+
+for mod in pnpm pagefind; do
+  EXISTS="$(run_node -e "const fs=require('fs');console.log(fs.existsSync('/app/node_modules/$mod')||fs.existsSync('/app/node_modules/.bin/$mod'))")"
+  [ "$EXISTS" = "false" ] || fail "expected '$mod' to be absent from the runtime node_modules"
+done
+pass "no pnpm / pagefind in the runtime node_modules"
+
+# next must be loadable — it is what server.js runs on.
+NEXT_VERSION="$(run_node -e "console.log(require('/app/node_modules/next/package.json').version)")"
+[ -n "$NEXT_VERSION" ] || fail "next is not loadable from the runtime image"
+pass "next $NEXT_VERSION loads from the pruned standalone node_modules"
+
+# --- 5. US2-AS1: no floating FROM -----------------------------------------
+[ -f "$DOCKERFILE" ] || fail "Dockerfile not found at $DOCKERFILE"
+while read -r line; do
+  echo "$line" | grep -q '@sha256:[0-9a-f]\{64\}' ||
+    fail "floating (non-digest-pinned) base image: $line"
+done < <(grep -E '^[[:space:]]*FROM[[:space:]]' "$DOCKERFILE")
+FROM_COUNT="$(grep -cE '^[[:space:]]*FROM[[:space:]]' "$DOCKERFILE")"
+pass "all $FROM_COUNT FROM stage(s) are digest-pinned"
+
+# --- 6. US7-AS1/2/3: live behaviour (the persisted D1/D2 regression) -------
+# NODE_ENV=dev is injected by the alkemio-config ConfigMap in dev/test/sandbox/
+# acceptance, and `envFrom` overrides the Dockerfile ENV — so the harness runs
+# the container the way the cluster actually will.
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+docker run -d --name "$CONTAINER" -e NODE_ENV=dev -p "$HOST_PORT:3010" "$IMAGE" >/dev/null
+B="http://localhost:$HOST_PORT"
+
+READY=""
+for _ in $(seq 1 60); do
+  if [ "$(curl -s -o /dev/null -w '%{http_code}' "$B/documentation" 2>/dev/null)" != "000" ]; then
+    READY=1; break
+  fi
+  sleep 1
+done
+[ -n "$READY" ] || { docker logs "$CONTAINER" >&2 || true; fail "container did not start listening on 3010"; }
+pass "container starts and listens on 3010 (with NODE_ENV=dev injected)"
+
+# 6a. basePath — 200 under /documentation, NOT merely on /.
+FINAL_CODE="$(curl -sL -o /dev/null -w '%{http_code}' "$B/documentation")"
+[ "$FINAL_CODE" = "200" ] || fail "expected HTTP 200 under the /documentation basePath, got $FINAL_CODE"
+pass "HTTP 200 under the /documentation basePath (US7-AS1)"
+
+# 6b. locale negotiation via proxy.js -> /documentation/en-US
+REDIR="$(curl -s -o /dev/null -w '%{redirect_url}' "$B/documentation")"
+case "$REDIR" in
+  */documentation/en-US) pass "/documentation redirects to /documentation/en-US (US7-AS3)" ;;
+  *) fail "expected a redirect to /documentation/en-US, got '$REDIR'" ;;
+esac
+
+# 6c. NEXT_LOCALE cookie honoured
+REDIR_NL="$(curl -s -o /dev/null -w '%{redirect_url}' -H 'Cookie: NEXT_LOCALE=nl-NL' "$B/documentation")"
+case "$REDIR_NL" in
+  */documentation/nl-NL) pass "NEXT_LOCALE=nl-NL is honoured (US7-AS3)" ;;
+  *) fail "expected the NEXT_LOCALE cookie to yield /documentation/nl-NL, got '$REDIR_NL'" ;;
+esac
+
+# 6d. pagefind index is present AND populated. Next does not copy public/ into
+# .next/standalone/ and pagefind writes after the build, so this asserts the
+# explicit `COPY public` survived.
+PF_CODE="$(curl -s -o /dev/null -w '%{http_code}' "$B/documentation/_pagefind/pagefind.js")"
+[ "$PF_CODE" = "200" ] || fail "pagefind.js not served (got $PF_CODE) — the runtime stage is missing public/_pagefind"
+PF_ENTRY="$(curl -s "$B/documentation/_pagefind/pagefind-entry.json")"
+echo "$PF_ENTRY" | grep -q '"page_count":[1-9]' ||
+  fail "pagefind index is present but EMPTY (page_count 0) — search would silently return nothing: $PF_ENTRY"
+pass "pagefind index served and non-empty (US7-AS2)"
+
+# 6e. .next/static is served — also outside the traced standalone output.
+# NB: `... | head -1` would SIGPIPE the upstream grep and, under `pipefail`,
+# abort the script with 141. Buffer first, then take the first match.
+CHUNK_LIST="$(curl -s "$B/documentation/en-US" | grep -oE '/documentation/_next/static/chunks/[A-Za-z0-9._-]+\.js' || true)"
+CHUNK="$(printf '%s\n' "$CHUNK_LIST" | sed -n '1p')"
+[ -n "$CHUNK" ] || fail "no static chunk referenced in the rendered page"
+CHUNK_CODE="$(curl -s -o /dev/null -w '%{http_code}' "$B$CHUNK")"
+[ "$CHUNK_CODE" = "200" ] || fail "static chunk $CHUNK not served (got $CHUNK_CODE) — the runtime stage is missing .next/static"
+pass "static assets served from .next/static"
+
+# 6f. a deep content route renders (not just the index)
+DEEP_CODE="$(curl -sL -o /dev/null -w '%{http_code}' "$B/documentation/faq")"
+[ "$DEEP_CODE" = "200" ] || fail "deep content route /documentation/faq returned $DEEP_CODE"
+pass "deep content route renders"
+
+# --- 7. evidence lines (US5-AS3) ------------------------------------------
+IMAGE_DIGEST="$(docker inspect "$IMAGE" --format '{{.Id}}')"
+IMAGE_SIZE_BYTES="$(docker save "$IMAGE" | wc -c)"
+echo "IMAGE_DIGEST=$IMAGE_DIGEST"
+echo "IMAGE_SIZE_BYTES=$IMAGE_SIZE_BYTES"
+
+echo "== distroless-image-smoke: ALL CHECKS PASSED =="

--- a/.docker/distroless-image-smoke.sh
+++ b/.docker/distroless-image-smoke.sh
@@ -184,11 +184,16 @@ pass "deep content route renders"
 
 # --- 7. evidence lines (US5-AS3) ------------------------------------------
 IMAGE_DIGEST="$(docker inspect "$IMAGE" --format '{{.Id}}')"
-# `docker inspect .Size`, NOT `docker save | wc -c`: on a runner that has just
-# built a multi-arch image, `docker save` streams every architecture in the
-# build cache, inflating the measurement ~3x against a correct image. `.Size`
-# counts only this image's layers, so it is architecture-correct anywhere.
-IMAGE_SIZE_BYTES="$(docker inspect "$IMAGE" --format '{{.Size}}')"
+# Sum `docker history` layer sizes rather than `docker inspect .Size`: on a
+# containerd-snapshotter daemon .Size counts only layers UNIQUE to this image,
+# so the same image measures ~3x smaller locally than on a CI runner using the
+# classic store. The history sum is store-independent.
+IMAGE_SIZE_BYTES="$(docker history --no-trunc --format '{{.Size}}' "$IMAGE" | awk '
+  /^[0-9.]+ *[kMG]?B$/ {
+    v=$0; sub(/ *[kMG]?B$/,"",v); u=$0; sub(/^[0-9.]+ */,"",u);
+    m = (u=="kB")?1000 : (u=="MB")?1000000 : (u=="GB")?1000000000 : 1;
+    total += v*m
+  } END { printf "%d", total }')"
 echo "IMAGE_DIGEST=$IMAGE_DIGEST"
 echo "IMAGE_SIZE_BYTES=$IMAGE_SIZE_BYTES"
 

--- a/.docker/distroless-image-smoke.sh
+++ b/.docker/distroless-image-smoke.sh
@@ -42,8 +42,14 @@ echo "== distroless-image-smoke: $IMAGE =="
 
 # --- 1. US1-AS1: declared user --------------------------------------------
 USER_ID="$(docker inspect "$IMAGE" --format '{{.Config.User}}')"
-[ "$USER_ID" = "65532" ] || [ "$USER_ID" = "nonroot" ] ||
-  fail "expected image user 65532/nonroot, got '$USER_ID' (an empty value means ROOT, and the hardened securityContext's runAsNonRoot would fail admission before start)"
+# Must be NUMERIC: the kubelet cannot resolve a non-numeric image user, so a
+# name form (`nonroot`) makes any Pod with `runAsNonRoot: true` fail admission
+# with "image has non-numeric user (nonroot), cannot verify user is non-root".
+# Proven on k8s-hetzner-sandbox during 036 verification.
+case "$USER_ID" in
+  65532|65532:65532) ;;
+  *) fail "expected numeric user 65532 or 65532:65532, got '$USER_ID' (a non-numeric user breaks runAsNonRoot admission)" ;;
+esac
 pass "image declares user '$USER_ID'"
 
 # The kubelet checks the declared user, but only the running process proves it.

--- a/.docker/distroless-image-smoke.sh
+++ b/.docker/distroless-image-smoke.sh
@@ -64,26 +64,28 @@ CMD_JSON="$(docker inspect "$IMAGE" --format '{{json .Config.Cmd}}')"
 pass "CMD is [\"server.js\"]"
 
 # --- no shell / no package manager -----------------------------------------
-# Probe for EXISTENCE on the filesystem, not exit status. A bare `docker run
-# --entrypoint apk <img>` exits non-zero on an image that HAS a working apk
-# (apk with no args is a usage error), so an exit-status test reports present
-# binaries as absent — it has no detection power. lstat (not existsSync) so a
-# dangling symlink still counts as a hit; Google's :debug variants put the
-# shell at /busybox/sh -> /busybox/busybox.
+# Sweep every PATH-shaped directory instead of probing a fixed denylist of
+# binary names: distroless ships /bin, /sbin, /usr/bin, /usr/sbin (and has no
+# /usr/local/bin or /busybox) EMPTY, so ANY entry appearing in one of them —
+# a shell, a package manager, busybox, anything — is a regression. This
+# closes the two holes the review proved in the earlier checks: (a) an
+# exit-status probe read working binaries as absent (apk with no args exits
+# non-zero), and (b) a fixed path list missed /busybox/sh, where Google's
+# :debug variants actually put the shell. lstat/readdir needs no exec
+# permission and sees dangling symlinks.
 FORBIDDEN="$(run_node -e "
 const fs = require('fs');
-const paths = [
-  '/bin/sh','/bin/bash','/usr/bin/sh','/usr/bin/bash',
-  '/busybox/sh','/busybox/busybox','/bin/busybox','/usr/bin/busybox',
-  '/sbin/apk','/usr/bin/apk','/usr/bin/apt','/usr/bin/apt-get','/usr/bin/dpkg',
-  '/usr/local/bin/npm','/usr/local/bin/npx','/usr/local/bin/yarn','/usr/local/bin/pnpm',
-  '/usr/bin/npm','/usr/bin/yarn','/usr/bin/pnpm',
-];
-const hits = paths.filter(p => { try { fs.lstatSync(p); return true; } catch { return false; } });
+const dirs = ['/bin','/sbin','/usr/bin','/usr/sbin','/usr/local/bin','/usr/local/sbin','/busybox'];
+const hits = [];
+for (const d of dirs) {
+  let entries = [];
+  try { entries = fs.readdirSync(d); } catch { continue; } // absent dir is fine
+  for (const e of entries) hits.push(d + '/' + e);
+}
 console.log(hits.join(','));
 ")"
-[ -z "$FORBIDDEN" ] || fail "shell/package-manager present in runtime image: $FORBIDDEN"
-pass "no shell / package manager present on the filesystem"
+[ -z "$FORBIDDEN" ] || fail "unexpected executables in runtime image PATH dirs: $FORBIDDEN"
+pass "PATH directories are empty (no shell / package manager / any binary)"
 
 # --- 4. US1-AS3: no sources, no build tooling in the runtime ---------------
 for path in app content components proxy.js mdx-components.js styles.css pnpm-lock.yaml; do

--- a/.docker/distroless-image-smoke.sh
+++ b/.docker/distroless-image-smoke.sh
@@ -184,7 +184,11 @@ pass "deep content route renders"
 
 # --- 7. evidence lines (US5-AS3) ------------------------------------------
 IMAGE_DIGEST="$(docker inspect "$IMAGE" --format '{{.Id}}')"
-IMAGE_SIZE_BYTES="$(docker save "$IMAGE" | wc -c)"
+# `docker inspect .Size`, NOT `docker save | wc -c`: on a runner that has just
+# built a multi-arch image, `docker save` streams every architecture in the
+# build cache, inflating the measurement ~3x against a correct image. `.Size`
+# counts only this image's layers, so it is architecture-correct anywhere.
+IMAGE_SIZE_BYTES="$(docker inspect "$IMAGE" --format '{{.Size}}')"
 echo "IMAGE_DIGEST=$IMAGE_DIGEST"
 echo "IMAGE_SIZE_BYTES=$IMAGE_SIZE_BYTES"
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,3 +27,29 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+  # workspace#036-distroless-wave-1 (DOC-12).
+  #
+  # The runtime image's hardening invariants (digest-pinned bases, USER 65532,
+  # no shell, no pnpm, no source tree) and — just as importantly — the site
+  # behaviours that the distroless move put at risk (200 under the
+  # /documentation basePath, proxy.js locale negotiation, and the pagefind
+  # index, which lives OUTSIDE Next's traced standalone output and so is only
+  # present because the Dockerfile copies public/ explicitly) are enforced only
+  # if something actually runs the smoke script. Otherwise they regress
+  # silently and surface post-merge — and this repo's merges to `develop`
+  # deploy straight to Hetzner dev AND Scaleway acceptance.
+  #
+  # This repo has no lint job and no test job, so this is its only behavioural
+  # gate.
+  image-hardening:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Build runtime image
+        run: docker build -t documentation:pr .
+
+      - name: Assert image hardening and site invariants
+        run: bash .docker/distroless-image-smoke.sh documentation:pr

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,57 +1,115 @@
-# Stage 1: Build the Next.js app
-FROM node:22.21.1-alpine AS build
+###############################################################################
+# workspace#036-distroless-wave-1 — `documentation`
+#
+# Two-stage build producing a distroless, non-root runtime image:
+#   1. build   — glibc (Debian trixie), full deps, `next build` + pagefind
+#   2. runtime — gcr.io/distroless/nodejs22-debian13:nonroot: no shell, no
+#                package manager, no sources, no dev dependencies, no pnpm.
+#
+# Why distroless-node and NOT nginx (agreed point A2):
+#   `next.config.mjs` has no `output: 'export'` and `proxy.js` performs
+#   per-request cookie / Accept-Language negotiation via `next/server`. There
+#   is no static export to serve, so a static file server cannot serve this
+#   site. The workspace#033 client-web nginx pattern is categorically
+#   inapplicable here.
+#
+# Why `output: 'standalone'` (ruling C2, gates DOC-4/DOC-5 — both PASSED):
+#   Standalone emits `.next/standalone/server.js` plus a pruned `node_modules`
+#   (4 top-level packages), which lets the runtime stage drop pnpm, the dev
+#   dependencies and the entire source tree. The old runtime stage ran
+#   `CMD ["pnpm","run","start"]`; distroless has no shell and no pnpm, so that
+#   form could not have survived in any case.
+#
+#   Next does NOT copy `public/` or `.next/static/` into the standalone tree
+#   (documented upstream behaviour requiring a manual copy), and pagefind
+#   writes `public/_pagefind` *after* the build — doubly outside the traced
+#   output. Hence the two explicit COPY lines below. This was verified, not
+#   assumed: gate D1 showed pagefind indexing 76 pages / 2 languages /
+#   3964 words, with `_pagefind` confirmed OUTSIDE `.next/standalone/`.
+#
+# Base images pinned by digest (resolved with
+# `docker buildx imagetools inspect <image>:<tag>` on 2026-08-05). Both are
+# top-level OCI index digests. Re-resolve tag *and* digest together on a bump.
+#
+#   node:22.21.1-trixie-slim   (matches the Volta pin 22.21.1; glibc/Debian 13)
+#     digest: sha256:c3bf4cf764467f1bf9789fde549971a2cf8e720196df6cf3f95bafa590e5f4af
+#   gcr.io/distroless/nodejs22-debian13:nonroot   (reports Node v22.23.2, ABI 127)
+#     digest: sha256:939d6f1671529d230f50b563578e9b5d206af58f038b10ebd7e1233023d4e167
+#
+# Debian 13 (trixie), not Debian 12: Google's distroless project has frozen the
+# Debian 12 variants — only Debian 13 receives fresh builds. Same rationale as
+# workspace#026. The builder moves off Alpine/musl onto Debian/glibc so that
+# builder and runtime share one libc family.
+#
+# NOTE ON `readOnlyRootFilesystem` (agreed point A12): it is deliberately NOT
+# applied to this workload. A Next standalone server run `--read-only` returns
+# HTTP 200 while logging EROFS prerender-cache failures — silent degradation
+# that sails past health checks. See the matching comment in
+# manifests/25-documentation-deployment-dev.yaml.
+###############################################################################
 
-# Install pnpm globally
+###############################################################################
+# Stage 1: build — full deps (incl. the pagefind dev dependency), `next build`,
+# then the package.json `postbuild` hook generates the pagefind index into
+# public/_pagefind.
+#
+# `.dockerignore` excludes node_modules, .next, public/_pagefind and .git, so
+# `COPY . .` cannot smuggle in a host-built artifact and the pagefind index is
+# always regenerated rather than inherited stale.
+###############################################################################
+FROM node:22.21.1-trixie-slim@sha256:c3bf4cf764467f1bf9789fde549971a2cf8e720196df6cf3f95bafa590e5f4af AS build
+
 RUN npm i -g pnpm@10.17.1
 
-# Set working directory inside the container
 WORKDIR /app
 
-# Copy package.json and pnpm-lock.yaml
 COPY package.json pnpm-lock.yaml ./
-
-# Install dependencies
 RUN pnpm install --frozen-lockfile
 
-# Copy the rest of the application files
 COPY . .
 
-# Build the Next.js application (creates the `.next` directory)
-# postbuild script runs automatically and generates pagefind search index
+# `next build` honours `output: 'standalone'`; `postbuild` then runs
+# `pagefind --site .next/server/app --output-path public/_pagefind`.
 RUN pnpm run build
 
-# Stage 2: Serve the Next.js app
-FROM node:22.21.1-alpine AS production
+###############################################################################
+# Stage 2: runtime — distroless, non-root (UID 65532).
+#
+# The base sets ENTRYPOINT ["/nodejs/bin/node"], so CMD is the script path.
+#
+# Unlike workspace#026's server image, `ENV PATH="/nodejs/bin:${PATH}"` is
+# deliberately NOT set here: no consumer of this image overrides `command:` or
+# `args:` with a bare `node ...` invocation. The single live apply path
+# (manifests/25-documentation-deployment-dev.yaml, used by all five deploy
+# workflows) sets no `command:` at all, so the image ENTRYPOINT always applies
+# and the PATH workaround would be dead configuration. Re-evaluate if a
+# consumer ever adds a bare-`node` command override.
+###############################################################################
+FROM gcr.io/distroless/nodejs22-debian13:nonroot@sha256:939d6f1671529d230f50b563578e9b5d206af58f038b10ebd7e1233023d4e167 AS runtime
 
-# Install pnpm globally
-RUN npm i -g pnpm@10.17.1
-
-# Set working directory inside the container
 WORKDIR /app
 
-# Copy only the necessary files from the build stage (to keep image size small)
-COPY --from=build /app/package.json /app/pnpm-lock.yaml ./
-COPY --from=build /app/.next ./.next
-COPY --from=build /app/public ./public
-COPY --from=build /app/next.config.mjs ./next.config.mjs
-COPY --from=build /app/mdx-components.js ./mdx-components.js
-COPY --from=build /app/proxy.js ./proxy.js
-COPY --from=build /app/styles.css ./styles.css
+# PORT/HOSTNAME are how the standalone server picks its listen address — it
+# does not read `next start -p`. HOSTNAME=0.0.0.0 is required for the kubelet
+# to reach the container; the standalone server otherwise binds localhost only.
+ENV NODE_ENV=production \
+    PORT=3010 \
+    HOSTNAME=0.0.0.0
 
-# Copy app router files
-COPY --from=build /app/app ./app
+# The traced standalone output: generated server.js + pruned node_modules.
+COPY --from=build --chown=65532:65532 /app/.next/standalone ./
+# NOT part of the traced output — must be copied explicitly.
+COPY --from=build --chown=65532:65532 /app/.next/static ./.next/static
+# Static assets, and critically the pagefind index written by `postbuild`.
+COPY --from=build --chown=65532:65532 /app/public ./public
 
-# Copy content files
-COPY --from=build /app/content ./content
-
-# Copy components
-COPY --from=build /app/components ./components
-
-# Install only production dependencies
-RUN pnpm install --prod --frozen-lockfile
-
-# Expose port 3010 for the application
 EXPOSE 3010
 
-# Start the Next.js app in production mode
-CMD ["pnpm", "run", "start"]
+# Explicit non-root user (US7-AS4, ruling C1's mandatory mitigation). The
+# kubelet evaluates `runAsNonRoot: true` against the IMAGE's declared user
+# before the container starts; the previous Dockerfile had NO USER directive,
+# so the image declared root and the hardened securityContext added in
+# manifests/25-documentation-deployment-dev.yaml would have failed admission.
+USER 65532
+
+CMD ["server.js"]

--- a/manifests/25-documentation-deployment-dev.yaml
+++ b/manifests/25-documentation-deployment-dev.yaml
@@ -1,3 +1,32 @@
+###############################################################################
+# workspace#036-distroless-wave-1 (DOC-7) — hardened securityContext.
+#
+# SCOPE WARNING — despite the "-dev" suffix, this ONE file is the ONLY live
+# apply path for the documentation Deployment, and it is applied by ALL FIVE
+# deploy workflows via `azure/k8s-deploy`:
+#   build-deploy-k8s-dev-hetzner.yml       (push: develop)
+#   build-deploy-k8s-acc-scaleway.yml      (push: develop)
+#   build-deploy-k8s-test-hetzner.yml      (workflow_dispatch)
+#   build-deploy-k8s-sandbox-hetzner.yml   (workflow_dispatch)
+#   build-deploy-k8s-prod-scaleway.yml     (push: main)
+# Edit it as a five-environment change, not a dev-only one.
+#
+# The two other Deployment copies of this workload —
+#   dev-orchestration/01-alkemio-platform/base/.../documentation/11-documentation-deployment.yml
+#   infrastructure-operations/orchestration/base/.../documentation/11-documentation-deployment.yml
+# — are ORPHANS: neither frontend/kustomization.yml lists them (both list only
+# the ingress route and the service), and `kustomize build` over all 16
+# overlays renders ZERO documentation Deployment objects. Do NOT "helpfully"
+# wire them in; that would silently create two more live apply paths. Tracked
+# as follow-up F3 (single ownership).
+#
+# Image/manifest atomicity: each workflow's `build` job pushes
+# `:${{ github.sha }}` built from the checked-out commit, and its `deploy` job
+# passes that exact tag to `azure/k8s-deploy` `images:` alongside THIS file
+# from the SAME commit. The securityContext below and the `USER 65532` added
+# to the Dockerfile in the same commit therefore always arrive together — in
+# every environment, including production when develop→main is promoted.
+###############################################################################
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -16,9 +45,41 @@ spec:
       labels:
         app: alkemio-documentation
     spec:
+      # Pod-level baseline. The runtime image declares `USER 65532` and the
+      # distroless `nonroot` user is UID/GID 65532 (verified in-image:
+      # `uid=65532 gid=65532`), so runAsNonRoot is satisfiable.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        # Inert today (this pod mounts no volumes) but correct if one is ever
+        # added, and it costs nothing.
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: alkemio-documentation
           image: rg.nl-ams.scw.cloud/alkemio/alkemio-documentation:latest
+          # Container-level context. Repeats the identity fields deliberately:
+          # container-level wins over pod-level, so stating them here means a
+          # future pod-level edit cannot silently relax this container.
+          #
+          # `readOnlyRootFilesystem` is DELIBERATELY ABSENT — do not "complete"
+          # this block by adding it. A Next.js standalone server on a read-only
+          # root filesystem returns HTTP 200 while logging EROFS failures when
+          # it writes its prerender cache: the pod stays Ready and serves
+          # traffic, so the degradation is invisible to every health check.
+          # Silent degradation past a green probe is worse than the residual
+          # risk it would remove. Re-evaluate only alongside an emptyDir mount
+          # for the cache directory. (workspace#036 agreed point A12.)
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           envFrom:
             - secretRef:
                 name: alkemio-secrets
@@ -27,5 +88,3 @@ spec:
           ports:
             - name: documentation
               containerPort: 3010
-
-

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,6 +12,20 @@ export default withNextra({
   images: {
     unoptimized: true,
   },
+  // workspace#036-distroless-wave-1 (DOC-4/DOC-6, ruling C2).
+  // Emits a self-contained `.next/standalone/` tree with a generated
+  // `server.js` and a pruned `node_modules`, so the runtime image needs no
+  // pnpm, no dev dependencies and no source tree — which is what makes a
+  // distroless runtime possible at all (distroless has no shell, so the old
+  // `CMD ["pnpm","run","start"]` could not survive).
+  //
+  // Next does NOT copy `public/` or `.next/static/` into the standalone tree,
+  // and pagefind writes `public/_pagefind` *after* the build — so the
+  // Dockerfile copies both explicitly. Verified empirically: gate D1 indexed
+  // 76 pages / 2 languages / 3964 words with `_pagefind` outside
+  // `.next/standalone/`; gate D2 then served it byte-identically to the
+  // pre-change image. See specs/036-distroless-wave-1/evidence/documentation/.
+  output: 'standalone',
   basePath: '/documentation',
   devIndicators: false,
   async redirects() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,13 @@ importers:
     dependencies:
       next:
         specifier: ^16.1.6
-        version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       nextra:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        version: 4.6.1(next@16.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nextra@4.6.1(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+        version: 4.6.1(next@16.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nextra@4.6.1(next@16.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -51,8 +51,8 @@ packages:
   '@chevrotain/utils@11.0.3':
     resolution: {integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==}
 
-  '@emnapi/runtime@1.8.1':
-    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
@@ -91,140 +91,149 @@ packages:
   '@iconify/utils@3.1.0':
     resolution: {integrity: sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==}
 
-  '@img/colour@1.0.0':
-    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -336,53 +345,53 @@ packages:
     resolution: {integrity: sha512-bMVoAKhpjTOPHkW/lprDPwv5aD4R4C3Irt8vn+SKA9wudLe9COLxOhurrKRsxmZccUbWXRF7vukNeGUAj5P8kA==}
     engines: {node: '>= 10'}
 
-  '@next/env@16.1.6':
-    resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
+  '@next/env@16.3.0':
+    resolution: {integrity: sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==}
 
-  '@next/swc-darwin-arm64@16.1.6':
-    resolution: {integrity: sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==}
+  '@next/swc-darwin-arm64@16.3.0':
+    resolution: {integrity: sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.1.6':
-    resolution: {integrity: sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==}
+  '@next/swc-darwin-x64@16.3.0':
+    resolution: {integrity: sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.1.6':
-    resolution: {integrity: sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==}
+  '@next/swc-linux-arm64-gnu@16.3.0':
+    resolution: {integrity: sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.1.6':
-    resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
+  '@next/swc-linux-arm64-musl@16.3.0':
+    resolution: {integrity: sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.1.6':
-    resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
+  '@next/swc-linux-x64-gnu@16.3.0':
+    resolution: {integrity: sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.1.6':
-    resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
+  '@next/swc-linux-x64-musl@16.3.0':
+    resolution: {integrity: sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.1.6':
-    resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
+  '@next/swc-win32-arm64-msvc@16.3.0':
+    resolution: {integrity: sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.1.6':
-    resolution: {integrity: sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==}
+  '@next/swc-win32-x64-msvc@16.3.0':
+    resolution: {integrity: sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -685,8 +694,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  baseline-browser-mapping@2.9.18:
-    resolution: {integrity: sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA==}
+  baseline-browser-mapping@2.11.12:
+    resolution: {integrity: sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   better-react-mathjax@2.3.0:
@@ -1417,8 +1427,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1432,8 +1442,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.1.6:
-    resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
+  next@16.3.0:
+    resolution: {integrity: sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -1546,8 +1556,8 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   property-information@7.1.0:
@@ -1685,17 +1695,22 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
-  sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1964,7 +1979,7 @@ snapshots:
 
   '@chevrotain/utils@11.0.3': {}
 
-  '@emnapi/runtime@1.8.1':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2016,101 +2031,111 @@ snapshots:
       '@iconify/types': 2.0.0
       mlly: 1.8.0
 
-  '@img/colour@1.0.0':
+  '@img/colour@1.1.0':
     optional: true
 
-  '@img/sharp-darwin-arm64@0.34.5':
+  '@img/sharp-darwin-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-darwin-x64@0.34.5':
+  '@img/sharp-darwin-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.3.2
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-ppc64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-riscv64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-s390x@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-wasm32@0.34.5':
+  '@img/sharp-freebsd-wasm32@0.35.3':
     dependencies:
-      '@emnapi/runtime': 1.8.1
+      '@img/sharp-wasm32': 0.35.3
     optional: true
 
-  '@img/sharp-win32-arm64@0.34.5':
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.5':
+  '@img/sharp-libvips-darwin-x64@1.3.2':
     optional: true
 
-  '@img/sharp-win32-x64@0.34.5':
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-wasm32@0.35.3':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
     optional: true
 
   '@isaacs/balanced-match@4.0.1': {}
@@ -2216,30 +2241,30 @@ snapshots:
       '@napi-rs/simple-git-win32-ia32-msvc': 0.1.22
       '@napi-rs/simple-git-win32-x64-msvc': 0.1.22
 
-  '@next/env@16.1.6': {}
+  '@next/env@16.3.0': {}
 
-  '@next/swc-darwin-arm64@16.1.6':
+  '@next/swc-darwin-arm64@16.3.0':
     optional: true
 
-  '@next/swc-darwin-x64@16.1.6':
+  '@next/swc-darwin-x64@16.3.0':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.1.6':
+  '@next/swc-linux-arm64-gnu@16.3.0':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.1.6':
+  '@next/swc-linux-arm64-musl@16.3.0':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.1.6':
+  '@next/swc-linux-x64-gnu@16.3.0':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.1.6':
+  '@next/swc-linux-x64-musl@16.3.0':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.1.6':
+  '@next/swc-win32-arm64-msvc@16.3.0':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.1.6':
+  '@next/swc-win32-x64-msvc@16.3.0':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -2575,7 +2600,7 @@ snapshots:
 
   bail@2.0.2: {}
 
-  baseline-browser-mapping@2.9.18: {}
+  baseline-browser-mapping@2.11.12: {}
 
   better-react-mathjax@2.3.0(react@19.2.4):
     dependencies:
@@ -3727,7 +3752,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.17: {}
 
   negotiator@1.0.0: {}
 
@@ -3736,37 +3761,38 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@next/env': 16.1.6
+      '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.9.18
+      baseline-browser-mapping: 2.11.12
       caniuse-lite: 1.0.30001766
-      postcss: 8.4.31
+      postcss: 8.5.23
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(react@19.2.4)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.1.6
-      '@next/swc-darwin-x64': 16.1.6
-      '@next/swc-linux-arm64-gnu': 16.1.6
-      '@next/swc-linux-arm64-musl': 16.1.6
-      '@next/swc-linux-x64-gnu': 16.1.6
-      '@next/swc-linux-x64-musl': 16.1.6
-      '@next/swc-win32-arm64-msvc': 16.1.6
-      '@next/swc-win32-x64-msvc': 16.1.6
-      sharp: 0.34.5
+      '@next/swc-darwin-arm64': 16.3.0
+      '@next/swc-darwin-x64': 16.3.0
+      '@next/swc-linux-arm64-gnu': 16.3.0
+      '@next/swc-linux-arm64-musl': 16.3.0
+      '@next/swc-linux-x64-gnu': 16.3.0
+      '@next/swc-linux-x64-musl': 16.3.0
+      '@next/swc-win32-arm64-msvc': 16.3.0
+      '@next/swc-win32-x64-msvc': 16.3.0
+      sharp: 0.35.3
     transitivePeerDependencies:
       - '@babel/core'
+      - '@types/node'
       - babel-plugin-macros
 
-  nextra-theme-docs@4.6.1(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nextra@4.6.1(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+  nextra-theme-docs@4.6.1(next@16.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nextra@4.6.1(next@16.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
     dependencies:
       '@headlessui/react': 2.2.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
-      next: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      nextra: 4.6.1(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      nextra: 4.6.1(next@16.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       react: 19.2.4
       react-compiler-runtime: 19.1.0-rc.3(react@19.2.4)
       react-dom: 19.2.4(react@19.2.4)
@@ -3778,7 +3804,7 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  nextra@4.6.1(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+  nextra@4.6.1(next@16.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@headlessui/react': 2.2.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3799,7 +3825,7 @@ snapshots:
       mdast-util-gfm: 3.1.0
       mdast-util-to-hast: 13.2.1
       negotiator: 1.0.0
-      next: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-compiler-runtime: 19.1.0-rc.3(react@19.2.4)
       react-dom: 19.2.4(react@19.2.4)
@@ -3913,9 +3939,9 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss@8.4.31:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -4143,41 +4169,42 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
-  semver@7.7.3:
+  semver@7.8.5:
     optional: true
 
   server-only@0.0.1: {}
 
-  sharp@0.34.5:
+  sharp@0.35.3:
     dependencies:
-      '@img/colour': 1.0.0
+      '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.7.3
+      semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
     optional: true
 
   shebang-command@2.0.0:


### PR DESCRIPTION
Part of **workspace#036-distroless-wave-1**, wave 1 of epic alkem-io/infrastructure-operations#2499. Sub-issue: #135.

## ⚠️ Deploy impact of merging — read first

**Merging this PR to `develop` auto-deploys to Hetzner dev AND Scaleway ACCEPTANCE** (`build-deploy-k8s-acc-scaleway.yml` triggers on `develop`). This is operator-accepted for this wave. **Production is NOT touched** — its workflow triggers on `main` and stays gated behind the usual `develop → main` promotion.

## What

1. **Dockerfile**: `node:22.21.1-alpine` → digest-pinned glibc builder + `gcr.io/distroless/nodejs22-debian13:nonroot`, ending in an explicit **`USER 65532`** (the old image declared root — no USER directive). Council decision recorded in the spec: **distroless-node, not nginx** — `next.config.mjs` has no `output` key and `proxy.js` does per-request cookie/Accept-Language negotiation, so a static file server cannot serve this site.
2. **`manifests/25-documentation-deployment-dev.yaml` hardened** — the highest-value fix in this slice: this ONE `-dev`-named file is applied by **all five environments including production**, and had no securityContext at all. Now: runAsNonRoot 65532, seccompProfile RuntimeDefault, allowPrivilegeEscalation false, capabilities drop ALL. Manifest+image apply atomically from the same commit via `azure/k8s-deploy` image substitution, so dev/acc cannot see a hardened manifest with the old root image; prod isn't redeployed until promotion.
3. `readOnlyRootFilesystem` deliberately **NOT** set — proven to return HTTP 200 while logging EROFS prerender-cache failures (silent degradation past green health checks).
4. **Do not "helpfully" wire in the other two Deployment copies** — `11-documentation-deployment.yml` in infra-ops and dev-orchestration are **orphans**: neither frontend `kustomization.yml` references them (verified by rendering). Ownership cleanup is a separate follow-up.

## Evidence

- trivy: **108 → 0 fixable HIGH/CRITICAL** — the largest reduction in the wave. OS findings 74 → 12 (19 → 0 HIGH/CRITICAL; the remaining 12 are unfixable MEDIUM/LOW, recorded not waived).
- Smoke harness (CI-wired): PATH-directory sweep with proven detection power; serves under basePath `/documentation` on 3010.
- Consumer inventory: 4 apply paths, ONE live (the in-repo manifest above).

Review: 3 rounds (panel → adversarial verification by execution → final gate). Security dimension: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hardened, minimal production container based on a distroless runtime.
  * Configured the application to run as a non-root user with reduced container privileges.
  * Enabled standalone deployment output for a self-contained runtime.

* **Bug Fixes**
  * Added automated checks for container startup, routing, redirects, locale handling, and static assets.

* **Chores**
  * Added continuous integration coverage for image hardening and runtime smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->