### PR TITLE
fix(ci): deploy acceptance via scw-generated v3 kubeconfig

### DIFF
--- a/.github/workflows/build-deploy-k8s-acc-scaleway.yml
+++ b/.github/workflows/build-deploy-k8s-acc-scaleway.yml
@@ -55,13 +55,12 @@ jobs:
           SCW_REGION: ${{ vars.SCW_REGION }}
         run: .scripts/configure-acceptance-v3-kubeconfig.sh
 
-      - name: Create Image Pull Secret
-        run: |
-          kubectl create secret docker-registry alkemio-documentation-secret \
-            --docker-server=${{ secrets.REGISTRY_LOGIN_SERVER }} \
-            --docker-username=${{ secrets.REGISTRY_USERNAME }} \
-            --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
-            --dry-run=client -o yaml | kubectl apply -f -
+      # The image pull secret is no longer created here. It is provisioned by
+      # GitOps (infrastructure-operations, overlays/*-v3/documentation-registry-secret.yml)
+      # so this workflow needs no `secrets: create/update` grant in the namespace —
+      # which would otherwise let the CI identity read every secret in `default`
+      # (database credentials, Kratos cookie secrets, the Oathkeeper JWKS).
+      # See alkem-io/infrastructure-operations#2517.
 
       - name: Deploy to Scaleway
         uses: azure/k8s-deploy@v7.0.0

--- a/.github/workflows/build-deploy-k8s-acc-scaleway.yml
+++ b/.github/workflows/build-deploy-k8s-acc-scaleway.yml
@@ -26,20 +26,34 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    # Supplies SCW_ACCESS_KEY / SCW_SECRET_KEY and the cluster coordinates,
+    # mirroring the acceptance-v3 environment in infrastructure-operations.
+    environment: acceptance-v3
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@v7
 
-      - name: Set up Kubeconfig for Scaleway
-        run: |
-          mkdir -p $HOME/.kube  # Ensure the .kube directory exists
-          echo "${{ secrets.KUBECONFIG_SECRET_SCALEWAY_ACC }}" > $HOME/.kube/config
-          chmod 600 $HOME/.kube/config
-
+      # Must precede the kubeconfig step: the fence in that script uses kubectl
+      # to verify which cluster the generated config actually points at.
       - name: Install Kubectl
         uses: azure/setup-kubectl@v5.1.0
         with:
           version: "v1.27.6" # Ensure this matches the version used in your cluster
+
+      # Generates the kubeconfig on the runner from Scaleway API credentials.
+      # Replaces the stored KUBECONFIG_SECRET_SCALEWAY_ACC secret, which still
+      # pointed at the DECOMMISSIONED pre-v3 cluster and made every deploy fail
+      # with `dial tcp 51.158.216.139:6443: i/o timeout` — while the workflow's
+      # overall status still showed green, because only this job failed.
+      - name: Configure and fence acceptance-v3
+        env:
+          SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
+          SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
+          SCW_CLUSTER_ID: ${{ vars.SCW_CLUSTER_ID }}
+          SCW_PROJECT_ID: ${{ vars.SCW_PROJECT_ID }}
+          SCW_ORGANIZATION_ID: ${{ vars.SCW_ORGANIZATION_ID }}
+          SCW_REGION: ${{ vars.SCW_REGION }}
+        run: .scripts/configure-acceptance-v3-kubeconfig.sh
 
       - name: Create Image Pull Secret
         run: |

--- a/.github/workflows/build-deploy-k8s-acc-scaleway.yml
+++ b/.github/workflows/build-deploy-k8s-acc-scaleway.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: "Login into ACR"
-        uses: azure/docker-login@v2
+        uses: azure/docker-login@15c4aadf093404726ab2ff205b2cdd33fa6d054c # v2
         with:
           login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -31,12 +31,16 @@ jobs:
     environment: acceptance-v3
     steps:
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # No git push from the deploy job; leaving the token in .git/config
+          # would expose it to every later step in a credential-bearing job.
+          persist-credentials: false
 
       # Must precede the kubeconfig step: the fence in that script uses kubectl
       # to verify which cluster the generated config actually points at.
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v5.1.0
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
         with:
           version: "v1.27.6" # Ensure this matches the version used in your cluster
 
@@ -63,7 +67,7 @@ jobs:
       # See alkem-io/infrastructure-operations#2517.
 
       - name: Deploy to Scaleway
-        uses: azure/k8s-deploy@v7.0.0
+        uses: azure/k8s-deploy@51ca02a8b7225fbd0924aac359c5b336a5f1e5b4 # v7.0.0
         with:
           manifests: |
             manifests/25-documentation-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-prod-scaleway.yml
+++ b/.github/workflows/build-deploy-k8s-prod-scaleway.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: "Login into ACR"
-        uses: azure/docker-login@v2
+        uses: azure/docker-login@15c4aadf093404726ab2ff205b2cdd33fa6d054c # v2
         with:
           login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -32,12 +32,16 @@ jobs:
     environment: production-v3
     steps:
       - name: "Checkout GitHub Action"
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # No git push from the deploy job; leaving the token in .git/config
+          # would expose it to every later step in a credential-bearing job.
+          persist-credentials: false
 
       # Must precede the kubeconfig step: the fence in that script uses kubectl
       # to verify which cluster the generated config actually points at.
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v5.1.0
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
         with:
           version: "v1.27.6" # Ensure this matches the version used in your cluster
 
@@ -68,7 +72,7 @@ jobs:
       # See alkem-io/infrastructure-operations#2517.
 
       - name: Deploy to Scaleway
-        uses: azure/k8s-deploy@v7.0.0
+        uses: azure/k8s-deploy@51ca02a8b7225fbd0924aac359c5b336a5f1e5b4 # v7.0.0
         with:
           manifests: |
             manifests/25-documentation-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-prod-scaleway.yml
+++ b/.github/workflows/build-deploy-k8s-prod-scaleway.yml
@@ -41,13 +41,12 @@ jobs:
         with:
           version: "v1.27.6" # Ensure this matches the version used in your cluster
 
-      - name: Create Image Pull Secret
-        run: |
-          kubectl create secret docker-registry alkemio-documentation-secret \
-            --docker-server=${{ secrets.REGISTRY_LOGIN_SERVER }} \
-            --docker-username=${{ secrets.REGISTRY_USERNAME }} \
-            --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
-            --dry-run=client -o yaml | kubectl apply -f -
+      # The image pull secret is no longer created here. It is provisioned by
+      # GitOps (infrastructure-operations, overlays/*-v3/documentation-registry-secret.yml)
+      # so this workflow needs no `secrets: create/update` grant in the namespace —
+      # which would otherwise let the CI identity read every secret in `default`
+      # (database credentials, Kratos cookie secrets, the Oathkeeper JWKS).
+      # See alkem-io/infrastructure-operations#2517.
 
       - name: Deploy to Scaleway
         uses: azure/k8s-deploy@v7.0.0

--- a/.scripts/acceptance-v3-target-fence.sh
+++ b/.scripts/acceptance-v3-target-fence.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Target fence for the Scaleway v3 ACCEPTANCE cluster.
+#
+# Ported from infrastructure-operations/.scripts/stage-p-target-fence.sh so the
+# two repos assert the same invariant with the same values. Keep them in step:
+# if the acceptance cluster is ever re-provisioned, BOTH copies must change.
+#
+# The point of this file is that a credential mix-up must fail loudly instead of
+# deploying somewhere unintended. It refuses to proceed unless the kubeconfig
+# that was just generated resolves to exactly the acceptance-v3 cluster, and it
+# explicitly rejects a production or decommissioned-acceptance context even if
+# one somehow satisfied the cluster-id check.
+
+acceptance_v3_target_cluster=63babd2d-2acc-4bcd-992a-46278088916c
+acceptance_v3_target_project=b038f044-d128-4011-8ffb-3eb8589ecc04
+acceptance_v3_target_endpoint=https://63babd2d-2acc-4bcd-992a-46278088916c.api.k8s.nl-ams.scw.cloud:6443
+
+acceptance_v3_validate_target_fence() {
+  local context=${1-} endpoint=${2-} project=${3-}
+  [[ -n $context ]] || { echo "FAIL: ACC-V3 TARGET FENCE: absent context" >&2; return 1; }
+  [[ $context != *"old-acceptance"* ]] || { echo "FAIL: ACC-V3 TARGET FENCE: old-acceptance context" >&2; return 1; }
+  [[ $context != *"production"* && $context != *"prod"* ]] || { echo "FAIL: ACC-V3 TARGET FENCE: production context" >&2; return 1; }
+  [[ $context == *"$acceptance_v3_target_cluster"* ]] || { echo "FAIL: ACC-V3 TARGET FENCE: unrecognised context" >&2; return 1; }
+  [[ $endpoint == "$acceptance_v3_target_endpoint" ]] || { echo "FAIL: ACC-V3 TARGET FENCE: unrecognised endpoint" >&2; return 1; }
+  [[ $project == "$acceptance_v3_target_project" ]] || { echo "FAIL: ACC-V3 TARGET FENCE: project mismatch" >&2; return 1; }
+}
+
+acceptance_v3_assert_target_fence() {
+  local context endpoint
+  context=$(kubectl config current-context 2>/dev/null) || {
+    echo "FAIL: ACC-V3 TARGET FENCE: absent context" >&2; return 1;
+  }
+  endpoint=$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null) || {
+    echo "FAIL: ACC-V3 TARGET FENCE: absent context" >&2; return 1;
+  }
+  : "${SCW_PROJECT_ID:?FAIL: ACC-V3 TARGET FENCE: project is absent}"
+  acceptance_v3_validate_target_fence "$context" "$endpoint" "$SCW_PROJECT_ID"
+}

--- a/.scripts/configure-acceptance-v3-kubeconfig.sh
+++ b/.scripts/configure-acceptance-v3-kubeconfig.sh
@@ -80,4 +80,6 @@ fi
 # shellcheck source=acceptance-v3-target-fence.sh
 . "$(dirname "$0")/acceptance-v3-target-fence.sh"
 acceptance_v3_assert_target_fence
-kubectl get --raw=/readyz
+# Bound the request: kubectl's default --request-timeout is 0 (no timeout), so an
+# unresponsive control plane would hang the deploy job with no diagnostic.
+kubectl get --raw=/readyz --request-timeout=30s

--- a/.scripts/configure-acceptance-v3-kubeconfig.sh
+++ b/.scripts/configure-acceptance-v3-kubeconfig.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# Generate a kubeconfig for the Scaleway v3 ACCEPTANCE cluster on the runner.
+#
+# Ported from infrastructure-operations/.scripts/configure-acceptance-v3-kubeconfig.sh.
+#
+# WHY THIS EXISTS: this repo previously authenticated with the stored
+# KUBECONFIG_SECRET_SCALEWAY_ACC org secret, which still points at the
+# DECOMMISSIONED pre-v3 acceptance cluster (51.158.216.139). Deploys therefore
+# failed with `dial tcp 51.158.216.139:6443: i/o timeout` while the workflow's
+# top-level status still read green, because only the deploy job failed.
+#
+# A kubeconfig cannot simply be re-stored as a secret: the v3 clusters issue
+# short-lived credentials via an `exec` plugin that shells out to the scw CLI,
+# which is not portable to a runner. `auth-method=legacy` below is what makes
+# the generated config self-contained and therefore usable in CI.
+#
+# Secrets are consumed from the environment and never echoed. Do not add
+# `set -x` here, and do not print $HOME/.kube/config.
+
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+: "${HOME:?HOME is required}"
+: "${GITHUB_PATH:?GITHUB_PATH is required}"
+: "${SCW_ACCESS_KEY:?SCW_ACCESS_KEY is required}"
+: "${SCW_SECRET_KEY:?SCW_SECRET_KEY is required}"
+: "${SCW_CLUSTER_ID:?SCW_CLUSTER_ID is required}"
+: "${SCW_PROJECT_ID:?SCW_PROJECT_ID is required}"
+: "${SCW_ORGANIZATION_ID:?SCW_ORGANIZATION_ID is required}"
+: "${SCW_REGION:?SCW_REGION is required}"
+
+readonly target_cluster=63babd2d-2acc-4bcd-992a-46278088916c
+readonly target_project=b038f044-d128-4011-8ffb-3eb8589ecc04
+readonly target_region=nl-ams
+# scaleway-cli v2.59.0 linux/amd64 — same pin as infrastructure-operations.
+readonly scw_cli_sha256=e9606386ddbf7885f06d5d585d04356559039c55252bf2abd99e55b69f3d94f6
+
+# Fail before touching any cluster if the environment points somewhere else.
+[[ $SCW_CLUSTER_ID == "$target_cluster" ]] || {
+  echo "FAIL: cluster id $SCW_CLUSTER_ID is not $target_cluster" >&2
+  exit 1
+}
+[[ $SCW_PROJECT_ID == "$target_project" ]] || {
+  echo "FAIL: project id $SCW_PROJECT_ID is not $target_project" >&2
+  exit 1
+}
+[[ $SCW_REGION == "$target_region" ]] || {
+  echo "FAIL: region $SCW_REGION is not $target_region" >&2
+  exit 1
+}
+
+umask 077
+mkdir -p "$RUNNER_TEMP/bin" "$HOME/.kube"
+curl --fail --location --silent --show-error \
+  --connect-timeout 10 --max-time 120 \
+  --retry 3 --retry-connrefused --retry-delay 2 \
+  --output "$RUNNER_TEMP/bin/scw" \
+  https://github.com/scaleway/scaleway-cli/releases/download/v2.59.0/scaleway-cli_2.59.0_linux_amd64
+echo "$scw_cli_sha256  $RUNNER_TEMP/bin/scw" | sha256sum --check
+chmod 700 "$RUNNER_TEMP/bin/scw"
+echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+export PATH="$RUNNER_TEMP/bin:$PATH"
+
+export SCW_DEFAULT_PROJECT_ID="$SCW_PROJECT_ID"
+export SCW_DEFAULT_ORGANIZATION_ID="$SCW_ORGANIZATION_ID"
+export SCW_DEFAULT_REGION="$SCW_REGION"
+
+# auth-method=legacy emits a static-token kubeconfig (no exec plugin), which is
+# what makes the result usable on a runner that has no scw profile.
+scw k8s kubeconfig get "$SCW_CLUSTER_ID" \
+  region="$SCW_REGION" auth-method=legacy \
+  > "$HOME/.kube/config"
+
+generated_context="$(kubectl config current-context)"
+target_context="acceptance-v3-$SCW_CLUSTER_ID"
+if [[ $generated_context != "$target_context" ]]; then
+  kubectl config rename-context "$generated_context" "$target_context" >/dev/null
+fi
+
+# shellcheck source=acceptance-v3-target-fence.sh
+. "$(dirname "$0")/acceptance-v3-target-fence.sh"
+acceptance_v3_assert_target_fence
+kubectl get --raw=/readyz


### PR DESCRIPTION
## The acceptance deploy has been failing silently

`build-deploy-k8s-acc-scaleway.yml` authenticates with the stored `KUBECONFIG_SECRET_SCALEWAY_ACC` org secret, which still points at the **decommissioned pre-v3 cluster**:

```
Unable to connect to the server: dial tcp 51.158.216.139:6443: i/o timeout
```

`51.158.216.139` resolves to the old acceptance cluster (`007e37da-…`). The v3 cluster is `63babd2d-…` at `51.15.117.232`.

**Why nobody noticed:** the workflow has two jobs. `build` succeeds and `deploy` fails, but the run's top-level status can still read green — I initially reported this feature as "deployed to acceptance" on exactly that basis, which is how it surfaced.

Acceptance is therefore still running its pre-036 image. Nothing is half-applied: the deploy fails at the connection stage, before any manifest is touched.

## Why the secret can't just be re-stored

v3 clusters issue credentials through an `exec` plugin that shells out to the `scw` CLI. That kubeconfig is not portable to a runner — a re-stored copy would reference a binary and profile that don't exist there, and would fail *after* looking correctly configured.

## The fix — the pattern infra-ops already uses

Generate the kubeconfig on the runner from Scaleway API credentials, with `auth-method=legacy` so the result is a self-contained static-token config.

- **`.scripts/configure-acceptance-v3-kubeconfig.sh`** — SHA-256-pinned `scw` CLI (v2.59.0), asserts cluster/project/region **before** any cluster access, then generates.
- **`.scripts/acceptance-v3-target-fence.sh`** — post-generation fence asserting the live context, endpoint and project are exactly acceptance-v3, and explicitly rejecting any production or old-acceptance context.
- **workflow** — declares `environment: acceptance-v3`; kubectl install now precedes the kubeconfig step, because the fence uses kubectl to inspect the result.

Both scripts are ports of their `infrastructure-operations` counterparts, with fence constants matched exactly. Keep them in step if the cluster is ever re-provisioned.

Secrets are consumed from the environment and never echoed.

### Fence verified

Unit-tested against six cases — accepts only genuine acceptance-v3:

| case | result |
|---|---|
| correct acceptance-v3 | accept |
| production context | reject |
| old decommissioned cluster | reject |
| right context, wrong endpoint | reject |
| right context, wrong project | reject |
| empty context | reject |

## ⚠️ Before merging

Create an **`acceptance-v3` environment** on this repo with:
- secrets `SCW_ACCESS_KEY`, `SCW_SECRET_KEY`
- vars `SCW_CLUSTER_ID`, `SCW_PROJECT_ID`, `SCW_ORGANIZATION_ID`, `SCW_REGION`

Same shape as the existing environment in `infrastructure-operations`. Without it the deploy fails on missing credentials — no worse than today, but it won't fix anything either.

Companion PR hardens the **production** path, which is *not* broken. Merge this one first and confirm a green deploy.

Refs: workspace#036-distroless-wave-1, spec 024 (Scaleway v3 migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Deployment Improvements**
  - Acceptance deployments now use the dedicated acceptance-v3 environment and cluster configuration.
  - Deployment setup validates credentials, configuration, cluster targeting, and readiness before proceeding.
  - Kubernetes access is generated dynamically and verified before deployment.

- **Safety Enhancements**
  - Added safeguards against targeting production, legacy acceptance environments, or mismatched clusters.
  - Deployment actions are pinned to verified revisions for greater consistency and security.
  - Image-pull configuration now relies on pre-provisioned infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->