### PR TITLE
fix(ci): fence production deploys to the v3 cluster

### DIFF
--- a/.github/workflows/build-deploy-k8s-prod-scaleway.yml
+++ b/.github/workflows/build-deploy-k8s-prod-scaleway.yml
@@ -26,20 +26,39 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    # Supplies SCW_PRODUCTION_V3_* credentials and cluster coordinates. Also a
+    # place to attach required reviewers or a branch policy later — production
+    # currently has neither.
+    environment: production-v3
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@v7
 
-      - name: Set up Kubeconfig for Scaleway
-        run: |
-          mkdir -p $HOME/.kube  # Ensure the .kube directory exists
-          echo "${{ secrets.KUBECONFIG_SECRET_SCALEWAY_PROD }}" > $HOME/.kube/config
-          chmod 600 $HOME/.kube/config
-
+      # Must precede the kubeconfig step: the fence in that script uses kubectl
+      # to verify which cluster the generated config actually points at.
       - name: Install Kubectl
         uses: azure/setup-kubectl@v5.1.0
         with:
           version: "v1.27.6" # Ensure this matches the version used in your cluster
+
+      # Generates the kubeconfig on the runner from Scaleway API credentials and
+      # fences it to the v3 production cluster before anything is applied.
+      #
+      # NOTE: unlike the acceptance path, this replaces a WORKING mechanism.
+      # KUBECONFIG_SECRET_SCALEWAY_PROD does point at v3 and deploys have been
+      # succeeding. What it lacks is a target fence — if that secret were ever
+      # rotated to the wrong cluster, this repo would deploy there silently,
+      # whereas infrastructure-operations fails closed. This adopts the same
+      # fail-closed pattern and drops a long-lived stored credential.
+      - name: Configure and fence production-v3
+        env:
+          SCW_PRODUCTION_V3_ACCESS_KEY: ${{ secrets.SCW_PRODUCTION_V3_ACCESS_KEY }}
+          SCW_PRODUCTION_V3_SECRET_KEY: ${{ secrets.SCW_PRODUCTION_V3_SECRET_KEY }}
+          SCW_PRODUCTION_V3_CLUSTER_ID: ${{ vars.SCW_PRODUCTION_V3_CLUSTER_ID }}
+          SCW_PRODUCTION_V3_PROJECT_ID: ${{ vars.SCW_PRODUCTION_V3_PROJECT_ID }}
+          SCW_PRODUCTION_V3_ORGANIZATION_ID: ${{ vars.SCW_PRODUCTION_V3_ORGANIZATION_ID }}
+          SCW_PRODUCTION_V3_REGION: ${{ vars.SCW_PRODUCTION_V3_REGION }}
+        run: .scripts/configure-production-v3-kubeconfig.sh
 
       - name: Create Image Pull Secret
         run: |

--- a/.scripts/configure-production-v3-kubeconfig.sh
+++ b/.scripts/configure-production-v3-kubeconfig.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# Generate a kubeconfig for the Scaleway v3 PRODUCTION cluster on the runner.
+#
+# Ported from infrastructure-operations/.scripts/configure-production-v3-kubeconfig.sh.
+#
+# WHY THIS EXISTS: unlike the acceptance path, production is NOT broken — the
+# stored KUBECONFIG_SECRET_SCALEWAY_PROD secret does point at v3 and deploys
+# have been succeeding (verified: 2026-07-21 run 29831746087 configured the
+# Deployment on the same namespace that infra-ops run 29563771867 had annotated,
+# and that run was fenced to cluster 62166d69-…).
+#
+# What the stored-secret approach lacks is a TARGET FENCE. If that secret is
+# ever rotated to the wrong cluster, this repo would deploy there silently,
+# whereas infrastructure-operations fails closed. This change buys that same
+# fail-closed property and removes a long-lived credential from the org secret
+# store in favour of short-lived, generated ones.
+#
+# Secrets are consumed from the environment and never echoed. Do not add
+# `set -x` here, and do not print $HOME/.kube/config.
+
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+: "${HOME:?HOME is required}"
+: "${GITHUB_PATH:?GITHUB_PATH is required}"
+: "${SCW_PRODUCTION_V3_ACCESS_KEY:?SCW_PRODUCTION_V3_ACCESS_KEY is required}"
+: "${SCW_PRODUCTION_V3_SECRET_KEY:?SCW_PRODUCTION_V3_SECRET_KEY is required}"
+: "${SCW_PRODUCTION_V3_CLUSTER_ID:?SCW_PRODUCTION_V3_CLUSTER_ID is required}"
+: "${SCW_PRODUCTION_V3_PROJECT_ID:?SCW_PRODUCTION_V3_PROJECT_ID is required}"
+: "${SCW_PRODUCTION_V3_ORGANIZATION_ID:?SCW_PRODUCTION_V3_ORGANIZATION_ID is required}"
+: "${SCW_PRODUCTION_V3_REGION:?SCW_PRODUCTION_V3_REGION is required}"
+
+readonly target_cluster=62166d69-76c6-43a1-85af-d0040c1449d0
+readonly target_project=069a6063-fb1d-427d-ab59-a69dc3971ccd
+readonly target_region=nl-ams
+readonly target_endpoint=https://62166d69-76c6-43a1-85af-d0040c1449d0.api.k8s.nl-ams.scw.cloud:6443
+# scaleway-cli v2.59.0 linux/amd64 — same pin as infrastructure-operations.
+readonly scw_cli_sha256=e9606386ddbf7885f06d5d585d04356559039c55252bf2abd99e55b69f3d94f6
+
+# Fail before touching any cluster if the environment points somewhere else.
+[[ $SCW_PRODUCTION_V3_CLUSTER_ID == "$target_cluster" ]] || {
+  echo "FAIL: cluster id $SCW_PRODUCTION_V3_CLUSTER_ID is not $target_cluster" >&2
+  exit 1
+}
+[[ $SCW_PRODUCTION_V3_PROJECT_ID == "$target_project" ]] || {
+  echo "FAIL: project id $SCW_PRODUCTION_V3_PROJECT_ID is not $target_project" >&2
+  exit 1
+}
+[[ $SCW_PRODUCTION_V3_REGION == "$target_region" ]] || {
+  echo "FAIL: region $SCW_PRODUCTION_V3_REGION is not $target_region" >&2
+  exit 1
+}
+
+umask 077
+mkdir -p "$RUNNER_TEMP/bin" "$HOME/.kube"
+curl --fail --location --silent --show-error \
+  --connect-timeout 10 --max-time 120 \
+  --retry 3 --retry-connrefused --retry-delay 2 \
+  --output "$RUNNER_TEMP/bin/scw" \
+  https://github.com/scaleway/scaleway-cli/releases/download/v2.59.0/scaleway-cli_2.59.0_linux_amd64
+echo "$scw_cli_sha256  $RUNNER_TEMP/bin/scw" | sha256sum --check
+chmod 700 "$RUNNER_TEMP/bin/scw"
+echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+export PATH="$RUNNER_TEMP/bin:$PATH"
+
+export SCW_ACCESS_KEY="$SCW_PRODUCTION_V3_ACCESS_KEY"
+export SCW_SECRET_KEY="$SCW_PRODUCTION_V3_SECRET_KEY"
+export SCW_DEFAULT_PROJECT_ID="$SCW_PRODUCTION_V3_PROJECT_ID"
+export SCW_DEFAULT_ORGANIZATION_ID="$SCW_PRODUCTION_V3_ORGANIZATION_ID"
+export SCW_DEFAULT_REGION="$SCW_PRODUCTION_V3_REGION"
+
+# auth-method=legacy emits a static-token kubeconfig (no exec plugin), which is
+# what makes the result usable on a runner that has no scw profile.
+scw k8s kubeconfig get "$SCW_PRODUCTION_V3_CLUSTER_ID" \
+  region="$SCW_PRODUCTION_V3_REGION" auth-method=legacy \
+  > "$HOME/.kube/config"
+
+generated_context="$(kubectl config current-context)"
+target_context="production-v3-$SCW_PRODUCTION_V3_CLUSTER_ID"
+if [[ $generated_context != "$target_context" ]]; then
+  kubectl config rename-context "$generated_context" "$target_context" >/dev/null
+fi
+
+# Target fence: assert what was actually generated, not what we asked for.
+current_context="$(kubectl config current-context)"
+current_endpoint="$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}')"
+[[ $current_context == "$target_context" ]] || {
+  echo "FAIL: context $current_context is not $target_context" >&2
+  exit 1
+}
+[[ $current_endpoint == "$target_endpoint" ]] || {
+  echo "FAIL: endpoint $current_endpoint is not $target_endpoint" >&2
+  exit 1
+}
+[[ $SCW_PRODUCTION_V3_PROJECT_ID == "$target_project" ]] || {
+  echo "FAIL: project id $SCW_PRODUCTION_V3_PROJECT_ID drifted from $target_project" >&2
+  exit 1
+}
+kubectl get --raw=/readyz


### PR DESCRIPTION
## ⚠️ Production is NOT broken — this is hardening

Unlike the companion acceptance PR (#137), which repairs a genuinely failing deploy, **this changes a working path.** Please read that distinction before merging.

`KUBECONFIG_SECRET_SCALEWAY_PROD` **does** point at the v3 cluster and deploys have been succeeding. Verified rather than assumed:

- run [29831746087](https://github.com/alkem-io/documentation/actions/runs/29831746087) (2026-07-21) reported `deployment.apps/alkemio-documentation-deployment configured`
- that run overwrote a namespace annotation left by `infrastructure-operations` run `29563771867`
- **that** run used `configure-production-v3-kubeconfig.sh`, hard-fenced to cluster `62166d69-…`

Two workflows writing the same namespace, one provably v3-fenced ⇒ this one is on v3 too.

## What's actually missing: a target fence

The stored-kubeconfig approach has no verification of *where it points*. If that secret were ever rotated to the wrong cluster, this repo would deploy there **silently** — whereas `infrastructure-operations` fails closed.

This adopts the same pattern:

1. assert cluster/project/region **before** any cluster access
2. generate a short-lived kubeconfig on the runner (`auth-method=legacy`, self-contained)
3. assert the generated context, endpoint **and** project after generation
4. probe `/readyz` before anything is applied

It also removes a long-lived stored credential from the org secret store in favour of generated, short-lived ones.

Fence constants are **byte-identical** to `infrastructure-operations/.scripts/configure-production-v3-kubeconfig.sh` — checked rather than transcribed, since this aims at production. Keep the two in step if the cluster is ever re-provisioned.

Kubectl install now precedes the kubeconfig step, because the fence uses kubectl to inspect what was generated. Secrets are consumed from the environment and never echoed.

## ⚠️ Before merging

Create a **`production-v3` environment** on this repo with:
- secrets `SCW_PRODUCTION_V3_ACCESS_KEY`, `SCW_PRODUCTION_V3_SECRET_KEY`
- vars `SCW_PRODUCTION_V3_CLUSTER_ID`, `_PROJECT_ID`, `_ORGANIZATION_ID`, `_REGION`

Same names `infrastructure-operations` already uses. **Until that exists, do not merge** — the current mechanism keeps working, so there is no urgency and no downside to holding.

The environment is also a natural place to attach required reviewers or a branch policy; production currently has neither.

### Suggested order

1. merge #137 (acceptance — fixes something broken)
2. confirm a green acceptance deploy
3. merge this, with the pattern already proven

Refs: workspace#036-distroless-wave-1, spec 024 (Scaleway v3 migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Production deployments now target the production-v3 environment.
  * Deployment configuration now uses validated Scaleway credentials and cluster details.
  * Added automated verification of the Kubernetes context, endpoint, and cluster readiness before deployment.
  * Sensitive credentials are handled securely and are no longer exposed during configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->