### PR TITLE
fix(ci): stop creating the pull secret in the v3 deploy workflows

### DIFF
--- a/.github/workflows/build-deploy-k8s-acc-scaleway.yml
+++ b/.github/workflows/build-deploy-k8s-acc-scaleway.yml
@@ -55,13 +55,12 @@ jobs:
           SCW_REGION: ${{ vars.SCW_REGION }}
         run: .scripts/configure-acceptance-v3-kubeconfig.sh
 
-      - name: Create Image Pull Secret
-        run: |
-          kubectl create secret docker-registry alkemio-documentation-secret \
-            --docker-server=${{ secrets.REGISTRY_LOGIN_SERVER }} \
-            --docker-username=${{ secrets.REGISTRY_USERNAME }} \
-            --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
-            --dry-run=client -o yaml | kubectl apply -f -
+      # The image pull secret is no longer created here. It is provisioned by
+      # GitOps (infrastructure-operations, overlays/*-v3/documentation-registry-secret.yml)
+      # so this workflow needs no `secrets: create/update` grant in the namespace —
+      # which would otherwise let the CI identity read every secret in `default`
+      # (database credentials, Kratos cookie secrets, the Oathkeeper JWKS).
+      # See alkem-io/infrastructure-operations#2517.
 
       - name: Deploy to Scaleway
         uses: azure/k8s-deploy@v7.0.0

--- a/.github/workflows/build-deploy-k8s-prod-scaleway.yml
+++ b/.github/workflows/build-deploy-k8s-prod-scaleway.yml
@@ -41,13 +41,12 @@ jobs:
         with:
           version: "v1.27.6" # Ensure this matches the version used in your cluster
 
-      - name: Create Image Pull Secret
-        run: |
-          kubectl create secret docker-registry alkemio-documentation-secret \
-            --docker-server=${{ secrets.REGISTRY_LOGIN_SERVER }} \
-            --docker-username=${{ secrets.REGISTRY_USERNAME }} \
-            --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
-            --dry-run=client -o yaml | kubectl apply -f -
+      # The image pull secret is no longer created here. It is provisioned by
+      # GitOps (infrastructure-operations, overlays/*-v3/documentation-registry-secret.yml)
+      # so this workflow needs no `secrets: create/update` grant in the namespace —
+      # which would otherwise let the CI identity read every secret in `default`
+      # (database credentials, Kratos cookie secrets, the Oathkeeper JWKS).
+      # See alkem-io/infrastructure-operations#2517.
 
       - name: Deploy to Scaleway
         uses: azure/k8s-deploy@v7.0.0


### PR DESCRIPTION
Pilot for the least-privilege CI deploy identity (alkem-io/infrastructure-operations#2517).

**Stacked on #137** — that PR rewrites the same acceptance workflow, so this targets its branch rather than `develop` to avoid a conflict. Merge #137 first; this will retarget automatically.

## What changed

Removes the `Create Image Pull Secret` step from the two **Scaleway v3** workflows. It ran:

```bash
kubectl create secret docker-registry alkemio-documentation-secret … | kubectl apply -f -
```

which requires `secrets: create/update` in the namespace — and a namespace-scoped secrets grant also lets the identity **read every secret in `default`** (database credentials, Kratos cookie secrets, the Oathkeeper JWKS). That would substantially undo the point of the new `deployer` tier.

The secret is now provisioned by GitOps — alkem-io/infrastructure-operations#2520.

## Deliberately retained

`imagepullsecrets: alkemio-documentation-secret` **stays**. The secret still exists and is still required to pull the image; it is simply no longer created here.

## Scope

The two v3 workflows only. The Hetzner dev/test/sandbox workflows target a different cluster with a different credential and still create the secret themselves — unchanged and verified (`grep` count 1 each, 0 for the v3 pair).

## ⚠️ Ordering

alkem-io/infrastructure-operations#2520 **must be applied to a cluster before** this deploys to it, or the pull secret will be absent and the image pull will fail.

## Verified

- both workflows still parse as valid YAML
- create-secret step count: acc-scaleway 0, prod-scaleway 0, the three Hetzner workflows 1 each

Refs alkem-io/infrastructure-operations#2517