### PR TITLE
fix: authenticate documentation deployer on acceptance v3

### DIFF
--- a/.github/workflows/build-deploy-k8s-acc-scaleway.yml
+++ b/.github/workflows/build-deploy-k8s-acc-scaleway.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Kubectl
         uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
         with:
-          version: "v1.27.6" # Ensure this matches the version used in your cluster
+          version: "v1.36.1"
 
       # Generates the kubeconfig on the runner from Scaleway API credentials.
       # Replaces the stored KUBECONFIG_SECRET_SCALEWAY_ACC secret, which still
@@ -53,6 +53,7 @@ jobs:
         env:
           SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
           SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
+          SCW_APPLICATION_ID: ${{ vars.SCW_APPLICATION_ID }}
           SCW_CLUSTER_ID: ${{ vars.SCW_CLUSTER_ID }}
           SCW_PROJECT_ID: ${{ vars.SCW_PROJECT_ID }}
           SCW_ORGANIZATION_ID: ${{ vars.SCW_ORGANIZATION_ID }}

--- a/.scripts/configure-acceptance-v3-kubeconfig.sh
+++ b/.scripts/configure-acceptance-v3-kubeconfig.sh
@@ -12,9 +12,11 @@ set -euo pipefail
 # top-level status still read green, because only the deploy job failed.
 #
 # A kubeconfig cannot simply be re-stored as a secret: the v3 clusters issue
-# short-lived credentials via an `exec` plugin that shells out to the scw CLI,
-# which is not portable to a runner. `auth-method=legacy` below is what makes
-# the generated config self-contained and therefore usable in CI.
+# credentials through an `exec` plugin that shells out to the scw CLI. This
+# script installs that CLI and a job-local mode-0600 profile, so the generated
+# kubeconfig is portable for the lifetime of this runner job without asking
+# Scaleway for a privileged legacy kubeconfig. The legacy endpoint rejects the
+# Project-scoped KubernetesReadOnly policy used by the deployer application.
 #
 # Secrets are consumed from the environment and never echoed. Do not add
 # `set -x` here, and do not print $HOME/.kube/config.
@@ -24,6 +26,7 @@ set -euo pipefail
 : "${GITHUB_PATH:?GITHUB_PATH is required}"
 : "${SCW_ACCESS_KEY:?SCW_ACCESS_KEY is required}"
 : "${SCW_SECRET_KEY:?SCW_SECRET_KEY is required}"
+: "${SCW_APPLICATION_ID:?SCW_APPLICATION_ID is required}"
 : "${SCW_CLUSTER_ID:?SCW_CLUSTER_ID is required}"
 : "${SCW_PROJECT_ID:?SCW_PROJECT_ID is required}"
 : "${SCW_ORGANIZATION_ID:?SCW_ORGANIZATION_ID is required}"
@@ -31,6 +34,9 @@ set -euo pipefail
 
 readonly target_cluster=63babd2d-2acc-4bcd-992a-46278088916c
 readonly target_project=b038f044-d128-4011-8ffb-3eb8589ecc04
+readonly target_application=17a221c4-613b-423d-b6c4-cb5245940fd4
+readonly target_deployer_group=scaleway:group:393445d9-6d83-4c5d-9880-1a83b96d67cf
+readonly target_admin_group=scaleway:group:54b80cea-7db9-4238-9cf3-406fd83592ba
 readonly target_region=nl-ams
 # scaleway-cli v2.59.0 linux/amd64 — same pin as infrastructure-operations.
 readonly scw_cli_sha256=e9606386ddbf7885f06d5d585d04356559039c55252bf2abd99e55b69f3d94f6
@@ -42,6 +48,10 @@ readonly scw_cli_sha256=e9606386ddbf7885f06d5d585d04356559039c55252bf2abd99e55b6
 }
 [[ $SCW_PROJECT_ID == "$target_project" ]] || {
   echo "FAIL: project id $SCW_PROJECT_ID is not $target_project" >&2
+  exit 1
+}
+[[ $SCW_APPLICATION_ID == "$target_application" ]] || {
+  echo "FAIL: application id $SCW_APPLICATION_ID is not $target_application" >&2
   exit 1
 }
 [[ $SCW_REGION == "$target_region" ]] || {
@@ -61,15 +71,38 @@ chmod 700 "$RUNNER_TEMP/bin/scw"
 echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
 export PATH="$RUNNER_TEMP/bin:$PATH"
 
-export SCW_DEFAULT_PROJECT_ID="$SCW_PROJECT_ID"
-export SCW_DEFAULT_ORGANIZATION_ID="$SCW_ORGANIZATION_ID"
-export SCW_DEFAULT_REGION="$SCW_REGION"
+# Keep the API key in a job-local profile. Unset the environment variables
+# before generating the kubeconfig: otherwise scw copies the token into the
+# kubeconfig instead of emitting the intended exec-credential reference.
+readonly scw_config="$RUNNER_TEMP/scw-documentation-acceptance-v3.yaml"
+printf 'access_key: %s\nsecret_key: %s\ndefault_organization_id: %s\ndefault_project_id: %s\ndefault_region: %s\ndefault_zone: %s\n' \
+  "$SCW_ACCESS_KEY" \
+  "$SCW_SECRET_KEY" \
+  "$SCW_ORGANIZATION_ID" \
+  "$SCW_PROJECT_ID" \
+  "$SCW_REGION" \
+  nl-ams-1 >"$scw_config"
+chmod 600 "$scw_config"
+unset SCW_ACCESS_KEY SCW_SECRET_KEY SCW_REGION
 
-# auth-method=legacy emits a static-token kubeconfig (no exec plugin), which is
-# what makes the result usable on a runner that has no scw profile.
-scw k8s kubeconfig get "$SCW_CLUSTER_ID" \
-  region="$SCW_REGION" auth-method=legacy \
+scw --config "$scw_config" k8s kubeconfig get "$SCW_CLUSTER_ID" \
+  region="$target_region" auth-method=cli \
   > "$HOME/.kube/config"
+
+# Fail if a future CLI change embeds a token or loses the job-local profile.
+[[ -z $(kubectl config view --minify --raw -o jsonpath='{.users[0].user.token}') ]] || {
+  echo "FAIL: generated kubeconfig embeds a bearer token" >&2
+  exit 1
+}
+[[ $(kubectl config view --minify --raw -o jsonpath='{.users[0].user.exec.command}') == scw ]] || {
+  echo "FAIL: generated kubeconfig has no scw exec credential" >&2
+  exit 1
+}
+exec_args=$(kubectl config view --minify --raw -o jsonpath='{.users[0].user.exec.args}')
+[[ $exec_args == *"$scw_config"* ]] || {
+  echo "FAIL: generated kubeconfig does not use the job-local scw profile" >&2
+  exit 1
+}
 
 generated_context="$(kubectl config current-context)"
 target_context="acceptance-v3-$SCW_CLUSTER_ID"
@@ -80,6 +113,66 @@ fi
 # shellcheck source=acceptance-v3-target-fence.sh
 . "$(dirname "$0")/acceptance-v3-target-fence.sh"
 acceptance_v3_assert_target_fence
-# Bound the request: kubectl's default --request-timeout is 0 (no timeout), so an
-# unresponsive control plane would hang the deploy job with no diagnostic.
+
+# Fence the credential as well as the target. The API key must belong to the
+# documentation application, carry the deployer group, and carry no broad or
+# admin path. ROLE is an IAM/RBAC property; an access-key name cannot downscope
+# a more privileged application.
+actual_username=$(kubectl auth whoami -o jsonpath='{.status.userInfo.username}')
+[[ $actual_username == "scaleway:bearer:$target_application" ]] || {
+  echo "FAIL: credential bearer $actual_username is not the documentation deployer application" >&2
+  exit 1
+}
+read -r -a actual_groups <<<"$(kubectl auth whoami -o jsonpath='{.status.userInfo.groups[*]}')"
+has_group() {
+  local expected=$1
+  local group
+  for group in "${actual_groups[@]}"; do
+    [[ $group == "$expected" ]] && return 0
+  done
+  return 1
+}
+
+has_group "$target_deployer_group" || {
+  echo "FAIL: credential is not in the acceptance-v3 deployer group" >&2
+  exit 1
+}
+if has_group scaleway:cluster-write || has_group system:masters || has_group "$target_admin_group"; then
+  echo "FAIL: credential has broad or administrator access" >&2
+  exit 1
+fi
+
+can_i() {
+  local result
+  result=$(kubectl auth can-i "$@" 2>/dev/null || true)
+  [[ $result == yes || $result == no ]] || {
+    echo "FAIL: unexpected authorization result for kubectl auth can-i $*" >&2
+    exit 1
+  }
+  printf '%s\n' "$result"
+}
+
+expect_can_i() {
+  local expected=$1
+  shift
+  local actual
+  actual=$(can_i "$@")
+  [[ $actual == "$expected" ]] || {
+    echo "FAIL: expected '$expected' for kubectl auth can-i $*, got '$actual'" >&2
+    exit 1
+  }
+}
+
+expect_can_i yes get pods -n default
+expect_can_i yes patch deployments.apps -n default
+expect_can_i yes create jobs.batch -n default
+expect_can_i yes patch services -n default
+expect_can_i no get secrets -n default
+expect_can_i no delete deployments.apps -n default
+expect_can_i no create pods/exec -n default
+expect_can_i no patch deployments.apps -n kube-system
+expect_can_i no create clusterrolebindings.rbac.authorization.k8s.io
+
+# Bound the request: kubectl's default --request-timeout is 0 (no timeout), so
+# an unresponsive control plane would hang the deploy job with no diagnostic.
 kubectl get --raw=/readyz --request-timeout=30s

--- a/.scripts/configure-acceptance-v3-kubeconfig.sh
+++ b/.scripts/configure-acceptance-v3-kubeconfig.sh
@@ -38,6 +38,7 @@ readonly target_application=17a221c4-613b-423d-b6c4-cb5245940fd4
 readonly target_deployer_group=scaleway:group:393445d9-6d83-4c5d-9880-1a83b96d67cf
 readonly target_admin_group=scaleway:group:54b80cea-7db9-4238-9cf3-406fd83592ba
 readonly target_region=nl-ams
+readonly kubectl_request_timeout=30s
 # scaleway-cli v2.59.0 linux/amd64 — same pin as infrastructure-operations.
 readonly scw_cli_sha256=e9606386ddbf7885f06d5d585d04356559039c55252bf2abd99e55b69f3d94f6
 
@@ -118,12 +119,12 @@ acceptance_v3_assert_target_fence
 # documentation application, carry the deployer group, and carry no broad or
 # admin path. ROLE is an IAM/RBAC property; an access-key name cannot downscope
 # a more privileged application.
-actual_username=$(kubectl auth whoami -o jsonpath='{.status.userInfo.username}')
+actual_username=$(kubectl auth whoami --request-timeout="$kubectl_request_timeout" -o jsonpath='{.status.userInfo.username}')
 [[ $actual_username == "scaleway:bearer:$target_application" ]] || {
   echo "FAIL: credential bearer $actual_username is not the documentation deployer application" >&2
   exit 1
 }
-read -r -a actual_groups <<<"$(kubectl auth whoami -o jsonpath='{.status.userInfo.groups[*]}')"
+read -r -a actual_groups <<<"$(kubectl auth whoami --request-timeout="$kubectl_request_timeout" -o jsonpath='{.status.userInfo.groups[*]}')"
 has_group() {
   local expected=$1
   local group
@@ -144,7 +145,7 @@ fi
 
 can_i() {
   local result
-  result=$(kubectl auth can-i "$@" 2>/dev/null || true)
+  result=$(kubectl auth can-i --request-timeout="$kubectl_request_timeout" "$@" 2>/dev/null || true)
   [[ $result == yes || $result == no ]] || {
     echo "FAIL: unexpected authorization result for kubectl auth can-i $*" >&2
     exit 1
@@ -168,6 +169,13 @@ expect_can_i yes patch deployments.apps -n default
 expect_can_i yes create jobs.batch -n default
 expect_can_i yes patch services -n default
 expect_can_i no get secrets -n default
+expect_can_i no list secrets -n default
+expect_can_i no watch secrets -n default
+expect_can_i no create secrets -n default
+expect_can_i no patch secrets -n default
+expect_can_i no update secrets -n default
+expect_can_i no delete secrets -n default
+expect_can_i no deletecollection secrets -n default
 expect_can_i no delete deployments.apps -n default
 expect_can_i no create pods/exec -n default
 expect_can_i no patch deployments.apps -n kube-system
@@ -175,4 +183,4 @@ expect_can_i no create clusterrolebindings.rbac.authorization.k8s.io
 
 # Bound the request: kubectl's default --request-timeout is 0 (no timeout), so
 # an unresponsive control plane would hang the deploy job with no diagnostic.
-kubectl get --raw=/readyz --request-timeout=30s
+kubectl get --raw=/readyz --request-timeout="$kubectl_request_timeout"


### PR DESCRIPTION
## Summary

- authenticate the acceptance deployment with a dedicated per-repository Scaleway application
- generate an exec-credential kubeconfig from a job-local mode-0600 CLI profile instead of the privileged legacy kubeconfig endpoint
- fence the exact application, deployer IAM group, allowed deployment operations, denied secret/admin operations, cluster identity and API readiness
- align kubectl with the acceptance-v3 Kubernetes version

## Reconciled acceptance environment

- Terraform membership applied: application `alkemio-documentation-acceptance-v3-deploy` -> `alkemio-acceptance-v3-deployer` (1 add, 0 change, 0 destroy)
- GitHub environment `acceptance-v3` now has the dedicated access/secret key plus `SCW_APPLICATION_ID` and existing cluster coordinates
- the long-lived CI key is stored in the operator password store at `alkemio/scaleway/acceptance-v3/deploy-documentation`
- no production identity, secret, environment or deployment was changed

## Why

The previous flow failed closed after #137 because the documentation environment had no API key. A least-privilege KubernetesReadOnly application can read the cluster and authenticate through `auth-method=cli`, but Scaleway rejects `auth-method=legacy`. Granting KubernetesFullAccess merely to obtain a legacy kubeconfig would defeat the deployer RBAC boundary.

## Verification

- live acceptance-v3 script run passed exact bearer and group checks
- allowed: get pods; patch deployments/services; create jobs in `default`
- denied: read secrets; delete deployments; exec into pods; patch `kube-system`; create ClusterRoleBindings
- `/readyz` returned `ok`
- `bash -n`
- ShellCheck 0.10.0
- actionlint 1.7.7
- `git diff --check`

The acceptance deployment will run when this PR is merged into `develop`; this PR does not deploy by itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated acceptance deployment tooling to use a newer Kubernetes command-line version.
  * Improved kubeconfig setup with stronger credential handling and validation.
  * Added checks to confirm deployment access is correctly scoped and excludes privileged permissions.
  * Enhanced readiness verification with a clearly bounded timeout for more predictable deployment checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->