### PR TITLE
fix(ci): align production kubectl with cluster

### DIFF
--- a/.github/workflows/build-deploy-k8s-prod-scaleway.yml
+++ b/.github/workflows/build-deploy-k8s-prod-scaleway.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Kubectl
         uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
         with:
-          version: "v1.27.6" # Ensure this matches the version used in your cluster
+          version: "v1.36.1"
 
       # Generates the kubeconfig on the runner from Scaleway API credentials and
       # fences it to the v3 production cluster before anything is applied.


### PR DESCRIPTION
## What

Pin the production deployment workflow to kubectl v1.36.1, matching both the production Kubernetes 1.36 cluster and the working acceptance workflow.

## Why

Production run 31389081633 failed closed in the target fence because kubectl v1.27.6 attempted a SelfSubjectReview API version unavailable on the cluster. The actual Kubernetes deployment step was skipped.

Failed job: https://github.com/alkem-io/documentation/actions/runs/31389081633/job/93456581269

## Validation

- git diff --check
- production and acceptance Scaleway workflows both resolve to kubectl v1.36.1
- signed commit with DCO sign-off

This PR does not rerun the workflow or mutate production.